### PR TITLE
Configure env vars in a separate .env file

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,11 @@ Broadly speaking, this sets things up as below:
 
 ## 2. Configure Response
 
-Response is configured using environment variables, which for local development can be set in the `docker-compose.yaml` file.
+Response is configured using environment variables in a `.env` file. Create your own:
+```
+$ cp env.example .env
+```
+and update the variables in it:
 
 ### OAuth Access Token (`SLACK_TOKEN`)
 


### PR DESCRIPTION
To customise these env vars, currently we have to edit the
docker-compose.yaml, which shows up as a git diff - there's the risk of
accidentally committing these changes. By use a .env file
([docs](https://docs.docker.com/compose/environment-variables/)) and
adding it to .gitignore, we can avoid this 🙏