### PR TITLE
Fix line endings on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf


### PR DESCRIPTION
Add .gitattributes so that shell scripts get the correct line endings when cloning on Windows.

This fixes the below error that was received:
```
response    | /app/startup.sh: line 2: $'\r': command not found
response    | /app/startup.sh: line 3: syntax error near unexpected token `$'\r''
'esponse    | /app/startup.sh: line 3: `wait_for_db()
```