### PR TITLE
Add status to Slack headline incident post

### DIFF
--- a/core/models/incident.py
+++ b/core/models/incident.py
@@ -85,3 +85,9 @@ class Incident(models.Model):
 
     def status_text(self):
         return 'resolved' if self.is_closed() else 'live'
+
+    def status_emoji(self):
+        if self.is_closed():
+            return ":droplet:"
+        else:
+            return ":fire:"   

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -45,6 +45,8 @@ services:
       TARGET_PORT: 8000
     ports:
       - "4040:4040"
+    depends_on:
+      - response
 
 volumes:
   postgres_data:

--- a/slack/models/headline_post.py
+++ b/slack/models/headline_post.py
@@ -42,6 +42,7 @@ class HeadlinePost(models.Model):
         msg.add_block(Divider())
 
         # Add additional info
+        msg.add_block(Section(block_id="status", text=Text(f"{self.incident.status_emoji()} Status: {self.incident.status_text().capitalize()}")))
         severity_text = self.incident.severity_text().capitalize() if self.incident.severity_text() else "-"
         msg.add_block(Section(block_id="severity", text=Text(f"{self.incident.severity_emoji()} Severity: {severity_text}")))
 


### PR DESCRIPTION
Add a status field to the incident headline post so that from a glance the status of the incident can be viewed without depending on the existence of the close button. 🔥 is shown for a live incident and 💧 is shown for an resolved incident.

I played around with the emoji's a little and settled on 🔥 and 💧 but open to suggestions on other combinations that could work.

Also added a dependency on response container for ngrok. 

![2019-05-08 20_40_19-Slack - AshleyPoole](https://user-images.githubusercontent.com/3891630/57404470-f2611e80-71d3-11e9-9f54-69ed7a69e6db.png)
![2019-05-08 20_43_52-Slack - AshleyPoole](https://user-images.githubusercontent.com/3891630/57404472-f2611e80-71d3-11e9-8c61-2d2ef7857a81.png)
