### PR TITLE
Add active and recent incident views

### DIFF
--- a/ui/static/incidents.css
+++ b/ui/static/incidents.css
@@ -1,0 +1,5 @@
+.no-incidents {
+    padding: 5px;
+    font-weight: bold;
+    margin-right: 5px;
+  }

--- a/ui/templates/incidents.html
+++ b/ui/templates/incidents.html
@@ -1,0 +1,52 @@
+{% extends "base.html" %}
+{% load static %}
+{% load unslackify %}
+
+{% block head %}
+<link rel="stylesheet" href="{% static "incidents.css" %}">
+{% endblock %}
+
+{% block content %}
+<div class="row pb-4">
+
+    <div class="col-lg-12 text-center">
+        {% comment %} ----- Heading ----- {% endcomment %}
+        <h1 class="mt-3" id="title">Incidents</h1>
+    </div>
+
+    {% if incidents.count > 0 %}
+    <div class="col-lg-12">
+        {% comment %} ----- Incidents ----- {% endcomment %}
+        <h2>{{ incident_filter}}</h2>
+        <div class="table-responsive">
+            <table id="incidents" class="table table-hover">
+                <tr class="d-flex">
+                    <th class="col-1">Incident</th>
+                    {%if show_status %}<th class="col-1">Status</th>{% endif %}
+                    <th class="col-2">Start Time</th>
+                    <th class="col-1">Severity</th>
+                    <th class="col-3">Summary</th>
+                    <th class="col-2">Reporter</th>
+                    <th class="col-2">Lead</th>
+                </tr>
+                {% for incident in incidents %}
+                    <tr class="d-flex">
+                        <td class="col-1"><a href="/incident/{{ incident.pk }}">{{ incident.pk }}</a></td>
+                        {%if show_status %}<td class="col-1" nowrap>{{ incident.status_text|upper }}</td>{% endif %}
+                        <td class="col-2">{{ incident.start_time }}</td>
+                        <td class="col-1">{% if incident.severity %}{{ incident.severity_text|upper }}{% endif %}</td>
+                        <td class="col-3">{{ incident.summary }}</td>
+                        <td class="col-2">{{ incident.reporter|slack_id_to_fullname }}</td>
+                        <td class="col-2">{% if incident.lead %}{{ incident.lead|slack_id_to_fullname }}{% endif %}</td>
+                    </tr>
+                {% endfor %}
+            </table>
+        </div>
+    </div>
+    {% endif %}
+
+    {% if incidents.count == 0 %}
+        <h4 class="no-incidents">Awesome, no incidents! &#128526;</h4>
+    {% endif %}
+</div>
+{% endblock %}

--- a/ui/urls.py
+++ b/ui/urls.py
@@ -5,4 +5,7 @@ import ui.views as views
 
 urlpatterns = [
     path('incident/<int:incident_id>/', views.incident_doc, name='incident_doc'),
+    path('', views.active_incidents, name='active_incidents'),
+    path('active', views.active_incidents, name='active_incidents'),
+    path('recent', views.recent_incidents, name='recent_incidents'),
 ]

--- a/ui/views.py
+++ b/ui/views.py
@@ -1,5 +1,7 @@
 from django.shortcuts import render
 from django.http import HttpRequest, HttpResponse, Http404
+from django.db.models import Q
+from datetime import datetime, timedelta
 
 from core.models import Incident
 from slack.models import PinnedMessage, UserStats
@@ -19,4 +21,25 @@ def incident_doc(request: HttpRequest, incident_id: str):
         "incident": incident,
         "events": events,
         "user_stats": user_stats,
+    })
+
+def active_incidents(request: HttpRequest):
+
+    active_incidents = Incident.objects.filter(end_time__isnull=True)
+
+    return render(request, template_name="incidents.html", context={
+        "incidents": active_incidents,
+        "incident_filter": "Active",
+        "show_status": False
+    })
+
+def recent_incidents(request: HttpRequest):
+
+    filter_date = datetime.now()-timedelta(days=14)
+    recent_incidents = Incident.objects.filter(Q(end_time__isnull=True)|Q(report_time__gte=filter_date))
+
+    return render(request, template_name="incidents.html", context={
+        "incidents": recent_incidents,
+        "incident_filter": "Recent",
+        "show_status": True
     })


### PR DESCRIPTION
Added new active and recent incident views, so you can see both active and recent incidents without using Slack or knowing the ID of a particular incident. Also set the home url to return active.

For now, I haven't added items to the nav bar, etc, as wanted to see if this would be accepted first.

![view_active](https://user-images.githubusercontent.com/3891630/57469508-b767f500-727e-11e9-8846-0fcf251e72af.png)

![view_recent](https://user-images.githubusercontent.com/3891630/57469513-ba62e580-727e-11e9-8e45-f41238c7c905.png)

![view_no_incidents](https://user-images.githubusercontent.com/3891630/57469516-bc2ca900-727e-11e9-80e8-2ddb2b48f9f1.png)

