### PR TITLE
Updated timeline events to sort by timestamp.

### DIFF
--- a/ui/templates/incident_doc.html
+++ b/ui/templates/incident_doc.html
@@ -54,7 +54,7 @@
         <h2>Timeline</h2>
         {% if events %}
         <div class="timeline">
-            {% for event in events.all %}
+            {% for event in events.all|dictsort:"timestamp" %}
             <div class="container">
                 <div class="content">
                     {{ event.icon|safe }}{{ event.timestamp|date:"H:i:s" }}

--- a/ui/templates/incident_doc.html
+++ b/ui/templates/incident_doc.html
@@ -54,7 +54,7 @@
         <h2>Timeline</h2>
         {% if events %}
         <div class="timeline">
-            {% for event in events.all|dictsort:"timestamp" %}
+            {% for event in events.all %}
             <div class="container">
                 <div class="content">
                     {{ event.icon|safe }}{{ event.timestamp|date:"H:i:s" }}

--- a/ui/views.py
+++ b/ui/views.py
@@ -12,7 +12,7 @@ def incident_doc(request: HttpRequest, incident_id: str):
     except Incident.DoesNotExist:
         raise Http404("Incident does not exist")
 
-    events = PinnedMessage.objects.filter(incident=incident)
+    events = PinnedMessage.objects.filter(incident=incident).order_by('timestamp')
     user_stats = UserStats.objects.filter(incident=incident).order_by('-message_count')[:5]
 
     return render(request, template_name='incident_doc.html', context={


### PR DESCRIPTION
As a user, I may review an incident channel and decide that I want messages farther back in the channel to be added to the incident timeline. Currently, the messages in the timeline are ordered by the time that they were pinned. I think it would be nice if they were ordered by the actual message timestamp instead of the pinned timestamp, otherwise it could lead to a misleading timeline.

Before
<img width="461" alt="Response-Before" src="https://user-images.githubusercontent.com/12090659/57469684-cfbf1c00-724c-11e9-92ab-eff79b1fba98.png">

After
<img width="465" alt="Response-After" src="https://user-images.githubusercontent.com/12090659/57469690-d3eb3980-724c-11e9-86d0-19f0ed9cc635.png">
