### PR TITLE
Add reminder to close the incident after 12 hours

### DIFF
--- a/slack/incident_notifications.py
+++ b/slack/incident_notifications.py
@@ -23,7 +23,7 @@ def remind_incident_lead(incident: Incident):
         pass
 
 @recurring_notification(interval_mins=720, max_notifications=6)
-def remind_incident_lead(incident: Incident):
+def remind_close_incident(incident: Incident):
     try:
         comms_channel = CommsChannel.objects.get(incident=incident)
         if not incident.is_closed():

--- a/slack/incident_notifications.py
+++ b/slack/incident_notifications.py
@@ -21,3 +21,12 @@ def remind_incident_lead(incident: Incident):
             comms_channel.post_in_channel("👩‍🚒 This incident hasn't got a lead.  Please set one with `@incident lead ...`")
     except CommsChannel.DoesNotExist:
         pass
+
+@recurring_notification(interval_mins=720, max_notifications=6)
+def remind_incident_lead(incident: Incident):
+    try:
+        comms_channel = CommsChannel.objects.get(incident=incident)
+        if not incident.is_closed():
+            comms_channel.post_in_channel(":timer_clock: This incident has been running a long time.  Can it be closed now?  Remember to pin important messages in order to create the timeline.")
+    except CommsChannel.DoesNotExist:
+        pass


### PR DESCRIPTION
Add a reminder to close the incident after 12 hours of having a comms channel open. This will help with incidents accidentally being left open.

![close_reminder](https://user-images.githubusercontent.com/3891630/57516712-20964980-730d-11e9-95ec-94e179ef1a9e.png)
