### PR TITLE
Guard against notification handlers throwing exceptions

### DIFF
--- a/slack/decorators/incident_notification.py
+++ b/slack/decorators/incident_notification.py
@@ -20,6 +20,9 @@ class NotificationHandler(object):
         self.interval_mins = interval_mins
         self.max_notifications = max_notifications
 
+    def __str__(self):
+        return self.key
+
 
 def single_notification(initial_delay_mins=0):
     """
@@ -79,7 +82,8 @@ def handle_notifications():
                     try:
                         handler.callback(incident)
                     except:
-                        pass
+                        logger.error(f"Error calling notification handler {handler}")
+
                     notification.time = datetime.now()
                     notification.repeat_count = notification.repeat_count + 1
                     notification.save()
@@ -92,7 +96,8 @@ def handle_notifications():
                     try:
                         handler.callback(incident)
                     except:
-                        pass
+                        logger.error(f"Error calling notification handler {handler}")
+
                     notification = Notification(
                         incident=incident,
                         key=handler.key,

--- a/slack/decorators/incident_notification.py
+++ b/slack/decorators/incident_notification.py
@@ -76,7 +76,10 @@ def handle_notifications():
                 # it's not exhausted its max_notifications, so wait 'interval_mins' before sending again
                 mins_since_last_notify = int((datetime.now() - notification.time).total_seconds() / 60)
                 if mins_since_last_notify >= handler.interval_mins:
-                    handler.callback(incident)
+                    try:
+                        handler.callback(incident)
+                    except:
+                        pass
                     notification.time = datetime.now()
                     notification.repeat_count = notification.repeat_count + 1
                     notification.save()
@@ -86,7 +89,10 @@ def handle_notifications():
                 # so wait until 'interval_mins' mins have elapsed from start
                 mins_since_started = int((datetime.now() - incident.start_time).total_seconds() / 60)
                 if mins_since_started >= handler.interval_mins:
-                    handler.callback(incident)
+                    try:
+                        handler.callback(incident)
+                    except:
+                        pass
                     notification = Notification(
                         incident=incident,
                         key=handler.key,


### PR DESCRIPTION
Prior to this change, a single notification handler failing would take out all notifications.
We expect exceptions to handled by the downstream function, and swallow them if they reach the main notification loop.