### PR TITLE
Handle channel creation when name has already been used

### DIFF
--- a/slack/models/comms_channel.py
+++ b/slack/models/comms_channel.py
@@ -16,7 +16,7 @@ class CommsChannelManager(models.Manager):
         "Creates a comms channel in slack, and saves a reference to it in the DB"
         try:
             name = f"inc-{100+incident.pk}"
-            channel_id = get_or_create_channel(name)
+            channel_id = get_or_create_channel(name, auto_unarchive=True)
         except SlackError as e:
             logger.error('Failed to create comms channel {e}')
 


### PR DESCRIPTION
This is very much an edge case, but if you try to create a comms channel when the name has been used already, _and_ the channel is archived, it'll fail ungracefully.
This patch auto-unarchives channels if they're re-used at the point of creation.

![image](https://user-images.githubusercontent.com/6616412/57986702-3c69c000-7a70-11e9-8a1a-90f098219b88.png)
