### PR TITLE
Show nicer text in Slack notifications

### DIFF
--- a/slack/block_kit.py
+++ b/slack/block_kit.py
@@ -8,7 +8,11 @@ slack_client = SlackClient(slack_token)
 
 class Message:
     def __init__(self):
+        self.fallback_text = None
         self.blocks = []
+
+    def set_fallback_text(self, text):
+        self.fallback_text = text
 
     def add_block(self, block):
         self.blocks.append(block)
@@ -27,6 +31,7 @@ class Message:
 
         response = slack_client.api_call(
             api_call,
+            text=self.fallback_text,
             channel=channel,
             ts=ts,
             blocks=self.serialize(),

--- a/slack/models/headline_post.py
+++ b/slack/models/headline_post.py
@@ -35,6 +35,9 @@ class HeadlinePost(models.Model):
         "Creates/updates the slack headline post with the latest incident info"
         msg = Message()
 
+        # Set the fallback text so notifications look nice
+        msg.set_fallback_text(f"{self.incident.report} reported by {user_reference(self.incident.reporter)}")
+
         # Add report/people
         msg.add_block(Section(block_id="report", text=Text(f"*{self.incident.report}*")))
         msg.add_block(Section(block_id="reporter", text=Text(f"🙋🏻‍♂️ Reporter: {user_reference(self.incident.reporter)}")))


### PR DESCRIPTION
Without this, block kit messages show `Content cannot be displayed` in notifications

![image](https://user-images.githubusercontent.com/6616412/59505632-dec56980-8e9d-11e9-9eb1-6b2b77734347.png)
