### PR TITLE
Fix severity text in dialog

### DIFF
--- a/slack/action_handlers.py
+++ b/slack/action_handlers.py
@@ -58,7 +58,7 @@ def handle_edit_incident_button(ac: ActionContext):
             TextArea(label="Summary", name="summary", value=ac.incident.summary, optional=True, placeholder="Can you share any more details?"),
             TextArea(label="Impact", name="impact", value=ac.incident.impact, optional=True, placeholder="Who or what might be affected?", hint="Think about affected people, systems, and processes"),
             SelectFromUsers(label="Lead", name="lead", value=ac.incident.lead.external_id if ac.incident.lead else None, optional=True),
-            SelectWithOptions([(i, s.capitalize()) for i, s in Incident.SEVERITIES], value=ac.incident.severity, label="Severity", name="severity", optional=True)
+            SelectWithOptions([(s.capitalize(), i) for i, s in Incident.SEVERITIES], value=ac.incident.severity, label="Severity", name="severity", optional=True)
         ]
     )
 

--- a/slack/views.py
+++ b/slack/views.py
@@ -42,7 +42,7 @@ def slash_command(request):
             TextArea(label="Summary", name="summary", optional=True, placeholder="Can you share any more details?"),
             TextArea(label="Impact", name="impact", optional=True, placeholder="Who or what might be affected?", hint="Think about affected people, systems, and processes"),
             SelectFromUsers(label="Lead", name="lead", optional=True),
-            SelectWithOptions([(i, s.capitalize()) for i, s in Incident.SEVERITIES], label="Severity", name="severity", optional=True)
+            SelectWithOptions([(s.capitalize(), i) for i, s in Incident.SEVERITIES], label="Severity", name="severity", optional=True)
         ]
     )
 


### PR DESCRIPTION
A [previous commit](https://github.com/monzo/response/commit/f840dfa1be89cc3f9d633e25800a89597c7738fc#diff-340b0d779d4d6c958691086a09615c15R85) reversed the label and value of severities used by dialogs.  This caused issues with the app, as we tried to access a dictionary with a string key rather than the expected integer.

![image](https://user-images.githubusercontent.com/6616412/60835684-b0485f00-a1bb-11e9-9fd8-ab9abcd899a0.png)
