### PR TITLE
Pagerduty Fixes

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,6 +18,7 @@ services:
     env_file: .env
     volumes:
       - ./:/app
+      - pypd:/app/pypd
     stdin_open: true
     tty: true
 
@@ -50,3 +51,4 @@ services:
 
 volumes:
   postgres_data:
+  pypd:

--- a/slack/workflows/pagerduty.py
+++ b/slack/workflows/pagerduty.py
@@ -68,10 +68,10 @@ def handle_escalatations(incident: Incident, user_id: str, message: str):
 @action_handler(ESCALATE_BUTTON)
 def handle_page_oncall_engineer(context: ActionContext):
     dialog = Dialog(
-        title=f"Escalate to {context.button_value}",
+        title=f"Escalate to a specialist",
         submit_label="Escalate",
         elements=[
-            DialogText(label="Message", name="message", placeholder="Why do you need them?", hint="You might be waking this person up.  Please make this friendly and clear."),
+            DialogText(label="Message", name="message", placeholder=f"Why do you need {context.button_value}?", hint="You might be waking this person up.  Please make this friendly and clear."),
         ],
         state=context.button_value
     )


### PR DESCRIPTION
- Avoid docker-compose volume mount from overwriting the pypd installation in the response container.
- Avoid overflowing the max dialog title length of 20 chars by fixing the string length.