### PR TITLE
Add shields to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+![PyPI](https://img.shields.io/pypi/v/django-incident-response.svg)
+![PyPI - Python Version](https://img.shields.io/pypi/pyversions/django-incident-response.svg)
+![PyPI - Django Version](https://img.shields.io/pypi/djversions/django-incident-response.svg)
+![Travis (.org)](https://img.shields.io/travis/monzo/response.svg)
+![GitHub](https://img.shields.io/github/license/monzo/response.svg)
+
 # Response ⚡
 
 Dealing with incidents can be stressful. On top of dealing with the issue at hand, responders are often responsible for handling comms, both internal and external, reporting, and coordinating the efforts of other engineers. To reduce the pressure and cognitive burden on its engineers, Monzo built Response to help coordinate and report incidents.


### PR DESCRIPTION
Many OSS projects use these shields (from https://shields.io/) to show various bits of status, metadata, etc. - these are the ones I've found which apply to the project. We possibly don't need all of them, but I thought I'd add them to see how they look