### PR TITLE
Improve logging/error handling in headline post update

### DIFF
--- a/response/errors.py
+++ b/response/errors.py
@@ -1,0 +1,4 @@
+
+
+class IncidentUpdateError(Exception):
+    pass

--- a/response/slack/models/headline_post.py
+++ b/response/slack/models/headline_post.py
@@ -1,14 +1,18 @@
+import logging
+
 from django.conf import settings
 from django.db import models
 from django.urls import reverse
 from urllib.parse import urljoin
 
+from response import errors
 from response.core.models.incident import Incident
 from response.slack.models.comms_channel import CommsChannel
 
 from response.slack.block_kit import *
 from response.slack.slack_utils import user_reference, channel_reference
 
+logger = logging.getLogger(__name__)
 
 class HeadlinePostManager(models.Manager):
     def create_headline_post(self, incident):
@@ -33,6 +37,7 @@ class HeadlinePost(models.Model):
 
     def update_in_slack(self):
         "Creates/updates the slack headline post with the latest incident info"
+        logging.info(f"Updating headline post in Slack for incident {self.incident.pk}")
         msg = Message()
 
         # Set the fallback text so notifications look nice
@@ -77,6 +82,13 @@ class HeadlinePost(models.Model):
 
         # Post / update the slack message
         response = msg.send(settings.INCIDENT_CHANNEL_ID, self.message_ts)
+        logging.info(f"Got response back from Slack after updating headline post: {response}")
+
+        # TODO: wrap this in a Slack helper library that turns ok=False into an exception we can catch
+        if not response.get("ok", False):
+            err = f"Slack returned an error from updating headline post: {response.get('error', '')}"
+            logging.error(err)
+            raise errors.IncidentUpdateError(f"Could not update headline post: {err}")
 
         # Save the message ts identifier if not already set
         if not self.message_ts:


### PR DESCRIPTION
This was useful for debugging issues I had setting up our private project.

At some point I'd like to more generally improve error handling - we should write a small wrapper around the Slack client which translates `ok: False` responses into exceptions.