### PR TITLE
Add better logging around Slack events + fix oauth scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ urlpatterns = [
   - `channels:history`
   - `channels:read`
   - `channels:write`
+  - `reactions:write`
   - `chat:write:bot`
   - `chat:write:user`
   - `users:read`

--- a/response/errors.py
+++ b/response/errors.py
@@ -1,0 +1,4 @@
+
+
+class IncidentUpdateError(Exception):
+    pass

--- a/response/slack/decorators/event_handler.py
+++ b/response/slack/decorators/event_handler.py
@@ -46,8 +46,11 @@ def handle_event(payload):
     event = payload.get('event', '')
     event_type = event.get('type', '')
 
+    logger.info(f"Handling Slack event {event} of type {event_type}")
+
     # ignore bot messages
     if event.get('subtype', None) == 'bot_message':
+        logger.info(f"Ignoring bot message")
         return
 
     # if it doesn't exist, error and return
@@ -73,4 +76,5 @@ def handle_event(payload):
 
     # call the registered handler
     for handler in EVENT_MAPPINGS[event_type]:
+        logger.info(f"Calling handler for event type {event_type} for incident {incident.pk}")
         handler(incident, payload['event'])

--- a/response/slack/decorators/incident_command.py
+++ b/response/slack/decorators/incident_command.py
@@ -74,6 +74,7 @@ def handle_incident_command(command_name, message, thread_ts, channel_id, user_i
         logger.error(f"No handler found for command {command_name}")
         return
 
+    logger.info(f"Handling incident command {command_name} '{message}' in channel {channel_id}")
     command = COMMAND_MAPPINGS[command_name]
 
     try:
@@ -90,27 +91,29 @@ def handle_incident_command(command_name, message, thread_ts, channel_id, user_i
 
     except CommsChannel.DoesNotExist:
         logger.error('No matching incident found for this channel')
+    except e:
+        logger.error(f"Error handling incident command {command_name} {message}: {e}")
 
 
 def react_not_ok(channel_id, thread_ts):
     try:
         remove_reaction('white_check_mark', channel_id, thread_ts)
-    except SlackError:
-        pass
+    except SlackError as e:
+        logger.error(f"Couldn't remove existing reaction from {channel_id} - {thread_ts}. Error: {e}")
 
     try:
         add_reaction('question', channel_id, thread_ts)
-    except SlackError:
-        pass
+    except SlackError as e:
+        logger.error(f"Couldn't add 'question' reaction to {channel_id} - {thread_ts}. Error: {e}")
 
 
 def react_ok(channel_id, thread_ts):
     try:
         remove_reaction('question', channel_id, thread_ts)
-    except SlackError:
-        pass
+    except SlackError as e:
+        logger.error(f"Couldn't remove existing reaction from {channel_id} - {thread_ts}. Error: {e}")
 
     try:
         add_reaction('white_check_mark', channel_id, thread_ts)
-    except SlackError:
-        pass
+    except SlackError as e:
+        logger.error(f"Couldn't add 'white_check_mark' reaction to {channel_id} - {thread_ts}. Error: {e}")

--- a/response/slack/models/headline_post.py
+++ b/response/slack/models/headline_post.py
@@ -1,14 +1,18 @@
+import logging
+
 from django.conf import settings
 from django.db import models
 from django.urls import reverse
 from urllib.parse import urljoin
 
+from response import errors
 from response.core.models.incident import Incident
 from response.slack.models.comms_channel import CommsChannel
 
 from response.slack.block_kit import *
 from response.slack.slack_utils import user_reference, channel_reference
 
+logger = logging.getLogger(__name__)
 
 class HeadlinePostManager(models.Manager):
     def create_headline_post(self, incident):
@@ -33,6 +37,7 @@ class HeadlinePost(models.Model):
 
     def update_in_slack(self):
         "Creates/updates the slack headline post with the latest incident info"
+        logging.info(f"Updating headline post in Slack for incident {self.incident.pk}")
         msg = Message()
 
         # Set the fallback text so notifications look nice
@@ -77,6 +82,13 @@ class HeadlinePost(models.Model):
 
         # Post / update the slack message
         response = msg.send(settings.INCIDENT_CHANNEL_ID, self.message_ts)
+        logging.info(f"Got response back from Slack after updating headline post: {response}")
+
+        # TODO: wrap this in a Slack helper library that turns ok=False into an exception we can catch
+        if not response.get("ok", False):
+            err = f"Slack returned an error from updating headline post: {response.get('error', '')}"
+            logging.error(err)
+            raise errors.IncidentUpdateError(f"Could not update headline post: {err}")
 
         # Save the message ts identifier if not already set
         if not self.message_ts:

--- a/response/slack/views.py
+++ b/response/slack/views.py
@@ -46,6 +46,8 @@ def slash_command(request):
         ]
     )
 
+    logger.info(f"Handling Slack slash command for user {user_id}, report {report} - opening dialog")
+
     dialog.send_open_dialog(INCIDENT_REPORT_DIALOG, trigger_id)
     return HttpResponse()
 
@@ -61,6 +63,8 @@ def action(request):
     """
     payload = json.loads(request.POST['payload'])
     action_type = payload['type']
+
+    logger.info(f"Handling Slack action of type '{action_type}'")
 
     if action_type == 'dialog_submission':
         handle_dialog.after_response(payload)
@@ -88,6 +92,8 @@ def event(request):
     """
     payload = json.loads(request.body)
     action_type = payload['type']
+
+    logger.info(f"Handling Slack event of type '{action_type}'")
 
     if action_type == 'event_callback':
         handle_event(payload)


### PR DESCRIPTION
Adding changes I've made whilst debugging why response wouldn't emoji
react to incident commands. I've added lots of logging - if it's too
noisy, I'm happy to tweak it in future PRs.

The culprit turned out to just be a missing Slack OAuth scope for emoji
reactions