### PR TITLE
Include newly moved templates

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
 include LICENSE
 include README.md
-recursive-include response/ui/static *
-recursive-include response/ui/templates *
+recursive-include response/static *
+recursive-include response/templates *


### PR DESCRIPTION
We moved the UI templates from response/ui to response - however the
package manifest was still looking for files to include from
response/ui/templates, so didn't actually package the templates.