### PR TITLE
Adds timezone to dates on event list

### DIFF
--- a/ui/templates/incident_doc.html
+++ b/ui/templates/incident_doc.html
@@ -57,7 +57,7 @@
             {% for event in events.all %}
             <div class="container">
                 <div class="content">
-                    {{ event.icon|safe }}{{ event.timestamp|date:"H:i:s" }}
+                    {{ event.icon|safe }}{{ event.timestamp|date:"H:i:s e" }}
                     {{ event|stringformat:'s'|unslackify|markdown_filter|safe  }}
                 </div>
             </div>


### PR DESCRIPTION
These are sometimes used to inform third parties/regulators and they are in UTC. It's important that recipients are able to determine local time of events and that we don't inadvertently misinform them.