### PR TITLE
 Populate headline post actions with @headline_post_action 

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -66,3 +66,31 @@ def handle_close_incident(action_context: ActionContext):
     incident.end_time = datetime.now()
     incident.save()
 ```
+
+### Headline Post Actions
+
+When a new incident is created, we create a "headline post" message in the central incidents channel. We add action buttons here - by default allowing creating an incident channel, editing the incident or closing. There is a decorator that allows you to add custom action buttons here - `@headline_post_action`.
+
+For example:
+```
+from response.slack import block_kit
+from response.slack.decorators import headline_post_action
+
+@headline_post_action(order=150)
+def my_cool_headline_action(headline_post):
+    return block_kit.Button(":sparkles: My cool action", "my-cool-action", value=headline_post.incident.pk)
+```
+
+You should provide a function which takes a `headline_post` parameter, and either returns `None` (a button won't be created) or an action, e.g. `block_kit.Button`. You can also specify an `order` parameter, which will determine the order in which actions appear. The default buttons have orders of 100, 200 and 300, so the above example would appear second:
+
+![](https://www.dropbox.com/s/ummtglal8xmw2rj/Screenshot%202019-08-08%2014.55.20.png?raw=1)
+
+Check the logs to see which actions have been registered, and what order they're registered in.
+
+```
+INFO  - headline_post_a - Registering headline post action create_comms_channel_action with order 100
+INFO  - headline_post_a - Registering headline post action edit_incident_button with order 200
+INFO  - headline_post_a - Registering headline post action close_incident_button with order 300
+INFO  - headline_post_a - Registering headline post action my_cool_headline_action with order 150
+```
+

--- a/response/slack/decorators/__init__.py
+++ b/response/slack/decorators/__init__.py
@@ -1,5 +1,6 @@
 from .action_handler import *
 from .event_handler import *
+from .headline_post_action import *
 from .incident_command import *
 from .keyword_handler import *
 from .incident_notification import *

--- a/response/slack/decorators/action_handler.py
+++ b/response/slack/decorators/action_handler.py
@@ -1,7 +1,7 @@
 import after_response
 
 from response.core.models.incident import Incident
-from response.slack.models import CommsChannel
+from response.slack.models.comms_channel import CommsChannel
 
 import logging
 logger = logging.getLogger(__name__)

--- a/response/slack/decorators/event_handler.py
+++ b/response/slack/decorators/event_handler.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 from django.core.exceptions import ObjectDoesNotExist, MultipleObjectsReturned
 
 from response.core.models.incident import Incident
-from response.slack.models import CommsChannel
+from response.slack.models.comms_channel import CommsChannel
 
 
 logger = logging.getLogger(__name__)

--- a/response/slack/decorators/headline_post_action.py
+++ b/response/slack/decorators/headline_post_action.py
@@ -29,8 +29,10 @@ def headline_post_action(order=0, func=None):
         SLACK_HEADLINE_POST_ACTION_MAPPINGS[
             order
         ] = SLACK_HEADLINE_POST_ACTION_MAPPINGS.get(order, []) + [fn]
+        logger.info(f"Registering headline post action {fn.__name__} with order {order}")
         return fn
 
     if func:
         return _wrapper(func)
+
     return _wrapper

--- a/response/slack/decorators/headline_post_action.py
+++ b/response/slack/decorators/headline_post_action.py
@@ -1,0 +1,36 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+SLACK_HEADLINE_POST_ACTION_MAPPINGS = {}
+
+
+def headline_post_action(order=0, func=None):
+    """headline_post_action
+
+    Decorator that allows adding a button/action into the headline post. Should be attached
+    to functions that take a HeadlinePost and return a Slack Action type (e.g. Button).
+
+    Actions can be conditional - returning None means that no Action will be added.
+
+    The order parameter determines the relative position the action appears in the post -
+    actions will be ordered low-high from left to right. Actions with the same order number
+    will be added in the order the decorator is executed, which depends on the order of file imports.
+
+    Usage:
+    @headline_post_action(100)
+    def edit_incident(headline_post):
+        return slack.block_kit.Button(":pencil2: Edit", EDIT_INCIDENT_BUTTON, value=headline_post.incident.pk)
+
+    """
+
+    def _wrapper(fn):
+        SLACK_HEADLINE_POST_ACTION_MAPPINGS[
+            order
+        ] = SLACK_HEADLINE_POST_ACTION_MAPPINGS.get(order, []) + [fn]
+        return fn
+
+    if func:
+        return _wrapper(func)
+    return _wrapper

--- a/response/slack/decorators/incident_command.py
+++ b/response/slack/decorators/incident_command.py
@@ -2,7 +2,7 @@ from django.conf import settings
 import logging
 
 from response.core.models import Incident
-from response.slack.models import CommsChannel
+from response.slack.models.comms_channel import CommsChannel
 from response.slack.client import SlackError
 
 logger = logging.getLogger(__name__)

--- a/response/slack/decorators/incident_notification.py
+++ b/response/slack/decorators/incident_notification.py
@@ -5,7 +5,8 @@ import logging
 from datetime import datetime
 
 from response.core.models import Incident
-from response.slack.models import CommsChannel, Notification
+from response.slack.models.comms_channel import CommsChannel
+from response.slack.models.notification import Notification
 
 logger = logging.getLogger(__name__)
 

--- a/response/slack/decorators/keyword_handler.py
+++ b/response/slack/decorators/keyword_handler.py
@@ -1,5 +1,5 @@
 from response.core.models.incident import Incident
-from response.slack.models import CommsChannel
+from response.slack.models.comms_channel import CommsChannel
 
 import logging
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
Adds a decorator that allows easily populating actions in headline
posts, so that we can add custom integrations there (e.g. PagerDuty).

Also adds a post_to_thread method in HeadlinePost