### PR TITLE
Add comms channel to incident API response

### DIFF
--- a/response/core/serializers.py
+++ b/response/core/serializers.py
@@ -1,11 +1,7 @@
+from response.core.models import Action
+from response.slack.models import CommsChannel, ExternalUser, Incident
+
 from rest_framework import serializers
-from rest_framework.decorators import action
-
-from response.core.models.incident import Incident
-from response.core.models.action import Action
-from response.core.models.user_external import ExternalUser
-
-from django.contrib.auth.models import User
 
 
 class ExternalUserSerializer(serializers.ModelSerializer):
@@ -28,14 +24,22 @@ class ActionSerializer(serializers.ModelSerializer):
         fields = ("pk", "details", "done", "incident", "user")
 
 
+class CommsChannelSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = CommsChannel
+        fields = ("channel_id",)
+
+
 class IncidentSerializer(serializers.ModelSerializer):
     reporter = ExternalUserSerializer(read_only=True)
     lead = ExternalUserSerializer()
+    comms_channel = CommsChannelSerializer(read_only=True)
 
     class Meta:
         model = Incident
         fields = (
             "action_set",
+            "comms_channel",
             "end_time",
             "impact",
             "lead",

--- a/response/slack/models/comms_channel.py
+++ b/response/slack/models/comms_channel.py
@@ -1,5 +1,3 @@
-from datetime import datetime
-from django.conf import settings
 from django.db import models
 from django.urls import reverse
 from urllib.parse import urljoin

--- a/tests/api/test_incidents.py
+++ b/tests/api/test_incidents.py
@@ -53,6 +53,8 @@ def test_list_incidents(arf, api_user):
         assert lead["display_name"]
         assert lead["external_id"]
 
+        assert incident["comms_channel"]
+
         # TODO: verify actions are serialised inline
 
 

--- a/tests/factories/incident.py
+++ b/tests/factories/incident.py
@@ -5,8 +5,13 @@ import factory
 from faker import Factory
 
 from response.core.models import Incident, ExternalUser
+from response.slack.models import CommsChannel
 
 faker = Factory.create()
+
+class CommsChannelFactory(factory.DjangoModelFactory):
+    class Meta:
+        model = CommsChannel
 
 
 @factory.django.mute_signals(post_save)
@@ -40,3 +45,5 @@ class IncidentFactory(factory.DjangoModelFactory):
     summary = factory.LazyFunction(
         lambda: faker.paragraph(nb_sentences=3, variable_nb_sentences=True)
     )
+
+    related_channel = factory.RelatedFactory(CommsChannelFactory, 'incident')


### PR DESCRIPTION
Uses `RelatedFactory` to create a comms channel in tests.