### PR TITLE
Add /api/incidents/<incident pk>/actions endpoint

### DIFF
--- a/response/core/models/incident.py
+++ b/response/core/models/incident.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from django.db import models
+from response import core
 from response.core.models.user_external import ExternalUser
 from response import slack
 
@@ -103,6 +104,9 @@ class Incident(models.Model):
             return ":droplet:"
         else:
             return ":fire:"
+
+    def action_items(self):
+        return core.models.Action.objects.filter(incident=self)
 
 
 # Used to store external identifiers

--- a/response/core/serializers.py
+++ b/response/core/serializers.py
@@ -11,17 +11,11 @@ class ExternalUserSerializer(serializers.ModelSerializer):
 
 
 class ActionSerializer(serializers.ModelSerializer):
-    # Serializers define the API representation.
-    incident = serializers.PrimaryKeyRelatedField(
-        queryset=Incident.objects.all(), required=False
-    )
-    user = serializers.PrimaryKeyRelatedField(
-        queryset=ExternalUser.objects.all(), required=False
-    )
+    user = ExternalUserSerializer(read_only=True)
 
     class Meta:
         model = Action
-        fields = ("pk", "details", "done", "incident", "user")
+        fields = ("pk", "details", "done", "user")
 
 
 class CommsChannelSerializer(serializers.ModelSerializer):
@@ -34,11 +28,12 @@ class IncidentSerializer(serializers.ModelSerializer):
     reporter = ExternalUserSerializer(read_only=True)
     lead = ExternalUserSerializer()
     comms_channel = CommsChannelSerializer(read_only=True)
+    action_items = ActionSerializer(read_only=True, many=True)
 
     class Meta:
         model = Incident
         fields = (
-            "action_set",
+            "action_items",
             "comms_channel",
             "end_time",
             "impact",

--- a/response/core/serializers.py
+++ b/response/core/serializers.py
@@ -11,11 +11,23 @@ class ExternalUserSerializer(serializers.ModelSerializer):
 
 
 class ActionSerializer(serializers.ModelSerializer):
-    user = ExternalUserSerializer(read_only=True)
+    user = ExternalUserSerializer()
 
     class Meta:
         model = Action
         fields = ("pk", "details", "done", "user")
+
+    def create(self, validated_data):
+        user = ExternalUser.objects.get(
+            display_name=validated_data["user"]["display_name"],
+            external_id=validated_data["user"]["external_id"],
+        )
+        validated_data["user"] = user
+        return Action.objects.create(**validated_data)
+
+    def update(self, instance, validated_data):
+        instance.save()
+        return instance
 
 
 class CommsChannelSerializer(serializers.ModelSerializer):

--- a/response/core/serializers.py
+++ b/response/core/serializers.py
@@ -16,6 +16,7 @@ class ActionSerializer(serializers.ModelSerializer):
     class Meta:
         model = Action
         fields = ("pk", "details", "done", "user")
+        read_only_fields = ("pk",)
 
     def create(self, validated_data):
         user = ExternalUser.objects.get(
@@ -27,11 +28,14 @@ class ActionSerializer(serializers.ModelSerializer):
         return Action.objects.create(**validated_data)
 
     def update(self, instance, validated_data):
-        instance.user = ExternalUser.objects.get(
-            app_id=validated_data["user"]["app_id"],
-            display_name=validated_data["user"]["display_name"],
-            external_id=validated_data["user"]["external_id"],
-        )
+        if "user" in validated_data:
+            instance.user = ExternalUser.objects.get(
+                app_id=validated_data["user"]["app_id"],
+                display_name=validated_data["user"]["display_name"],
+                external_id=validated_data["user"]["external_id"],
+            )
+        instance.details = validated_data.get("details", instance.details)
+        instance.done = validated_data.get("done", instance.done)
         instance.save()
         return instance
 

--- a/response/core/serializers.py
+++ b/response/core/serializers.py
@@ -19,6 +19,7 @@ class ActionSerializer(serializers.ModelSerializer):
 
     def create(self, validated_data):
         user = ExternalUser.objects.get(
+            app_id=validated_data["user"]["app_id"],
             display_name=validated_data["user"]["display_name"],
             external_id=validated_data["user"]["external_id"],
         )
@@ -26,6 +27,11 @@ class ActionSerializer(serializers.ModelSerializer):
         return Action.objects.create(**validated_data)
 
     def update(self, instance, validated_data):
+        instance.user = ExternalUser.objects.get(
+            app_id=validated_data["user"]["app_id"],
+            display_name=validated_data["user"]["display_name"],
+            external_id=validated_data["user"]["external_id"],
+        )
         instance.save()
         return instance
 

--- a/response/core/urls.py
+++ b/response/core/urls.py
@@ -1,16 +1,22 @@
 from django.conf.urls import url, include
 from rest_framework import routers
 
-from response.core.views import IncidentViewSet, ActionViewSet, ExternalUserViewSet
+from response.core.views import (
+    IncidentViewSet,
+    IncidentActionViewSet,
+    ActionViewSet,
+    ExternalUserViewSet,
+)
 
 # Routers provide an easy way of automatically determining the URL conf.
 router = routers.DefaultRouter()
-router.register(r'incidents', IncidentViewSet, basename='incident')
-router.register(r'actions', ActionViewSet)
-router.register(r'ExternalUser', ExternalUserViewSet)
+router.register(r"incidents", IncidentViewSet, basename="incident")
+router.register(
+    r"incidents/(?P<incident_pk>[0-9]+)/actions", IncidentActionViewSet, basename="incident-action"
+)
+router.register(r"actions", ActionViewSet)
+router.register(r"ExternalUser", ExternalUserViewSet)
 
 # Wire up our API using automatic URL routing.
 # Additionally, we include login URLs for the browsable API.
-urlpatterns = [
-    url(r'^', include(router.urls)),
-]
+urlpatterns = [url(r"^", include(router.urls))]

--- a/response/core/views.py
+++ b/response/core/views.py
@@ -33,3 +33,16 @@ class IncidentViewSet(viewsets.ModelViewSet):
 
     serializer_class = serializers.IncidentSerializer
     pagination_class = pagination.LimitOffsetPagination
+
+
+class IncidentActionViewSet(viewsets.ModelViewSet):
+
+    serializer_class = serializers.ActionSerializer
+
+    def get_queryset(self):
+        incident_pk = self.kwargs["incident_pk"]
+        return Action.objects.filter(incident_id=incident_pk)
+
+    def perform_create(self, serializer):
+        incident_pk = self.kwargs["incident_pk"]
+        serializer.save(incident_id=incident_pk)

--- a/tests/api/test_actions.py
+++ b/tests/api/test_actions.py
@@ -110,3 +110,23 @@ def update_action(arf, api_user, incident_id, action_data):
     return IncidentActionViewSet.as_view({"put": "update"})(
         req, incident_pk=incident_id, pk=action_data["pk"]
     )
+
+
+def test_delete_action(arf, api_user):
+    incident = IncidentFactory.create()
+    user = ExternalUserFactory.create()
+
+    action = ActionFactory.create(user=user, incident=incident)
+
+    req = arf.delete(
+        reverse("incident-action-list", kwargs={"incident_pk": incident.pk}),
+        format="json",
+    )
+    force_authenticate(req, user=api_user)
+    response = IncidentActionViewSet.as_view({"delete": "destroy"})(
+        req, incident_pk=incident.pk, pk=action.pk
+    )
+
+    assert response.status_code == 204, "Got non-204 response from API"
+    with pytest.raises(Action.DoesNotExist):
+        Action.objects.get(pk=action.pk)

--- a/tests/api/test_actions.py
+++ b/tests/api/test_actions.py
@@ -1,0 +1,53 @@
+import json
+import pytest
+from django.urls import reverse
+from rest_framework.test import force_authenticate
+
+from response import serializers
+from response.models import Action
+from response.core.views import IncidentActionViewSet
+
+from tests.factories import ActionFactory, ExternalUserFactory, IncidentFactory
+
+
+def test_list_actions_by_incident(arf, api_user):
+    incident = IncidentFactory.create()
+
+    req = arf.get(reverse("incident-action-list", kwargs={"incident_pk": incident.pk}))
+    force_authenticate(req, user=api_user)
+    response = IncidentActionViewSet.as_view({"get": "list"})(
+        req, incident_pk=incident.pk
+    )
+
+    content = json.loads(response.rendered_content)
+    print(content)
+    assert response.status_code == 200, "Got non-200 response from API"
+
+    assert len(content["results"]) == len(incident.action_items())
+    for action in content["results"]:
+        assert action["details"]
+        assert "done" in action
+        assert action["user"]
+
+
+def test_create_action(arf, api_user):
+    incident = IncidentFactory.create()
+    user = ExternalUserFactory.create()
+
+    action_model = ActionFactory.build(user=user)
+    action = serializers.ActionSerializer(action_model).data
+
+    req = arf.post(
+        reverse("incident-action-list", kwargs={"incident_pk": incident.pk}),
+        action,
+        format="json",
+    )
+    force_authenticate(req, user=api_user)
+    response = IncidentActionViewSet.as_view({"post": "create"})(
+        req, incident_pk=incident.pk
+    )
+
+    assert response.status_code == 201, "Got non-201 response from API"
+
+    new_action = Action.objects.get(details=action_model.details)
+

--- a/tests/api/test_incidents.py
+++ b/tests/api/test_incidents.py
@@ -60,7 +60,6 @@ def test_list_incidents(arf, api_user):
             assert action["details"]
             assert "done" in action
             assert action["user"]
-        # TODO: verify actions are serialised inline
 
 
 @pytest.mark.parametrize(

--- a/tests/api/test_incidents.py
+++ b/tests/api/test_incidents.py
@@ -55,6 +55,11 @@ def test_list_incidents(arf, api_user):
 
         assert incident["comms_channel"]
 
+        assert incident["action_items"]
+        for action in incident["action_items"]:
+            assert action["details"]
+            assert "done" in action
+            assert action["user"]
         # TODO: verify actions are serialised inline
 
 

--- a/tests/factories/action.py
+++ b/tests/factories/action.py
@@ -1,0 +1,22 @@
+import factory
+from faker import Factory
+
+from response.core.models import Action
+
+from .user import ExternalUserFactory
+
+faker = Factory.create()
+
+class ActionFactory(factory.DjangoModelFactory):
+    class Meta:
+        model = Action
+
+    user = factory.SubFactory('tests.factories.ExternalUserFactory')
+
+    details = factory.LazyFunction(
+        lambda: faker.paragraph(nb_sentences=1, variable_nb_sentences=True)
+    )
+
+    done = factory.LazyFunction(
+        lambda: faker.boolean(chance_of_getting_true=25)
+    )

--- a/tests/factories/incident.py
+++ b/tests/factories/incident.py
@@ -7,7 +7,10 @@ from faker import Factory
 from response.core.models import Incident, ExternalUser
 from response.slack.models import CommsChannel
 
+from .action import ActionFactory
+
 faker = Factory.create()
+
 
 class CommsChannelFactory(factory.DjangoModelFactory):
     class Meta:
@@ -46,4 +49,7 @@ class IncidentFactory(factory.DjangoModelFactory):
         lambda: faker.paragraph(nb_sentences=3, variable_nb_sentences=True)
     )
 
-    related_channel = factory.RelatedFactory(CommsChannelFactory, 'incident')
+    related_channel = factory.RelatedFactory(CommsChannelFactory, "incident")
+    related_action_items = factory.RelatedFactoryList(
+        ActionFactory, "incident", size=lambda: random.randint(1, 5)
+    )


### PR DESCRIPTION
Adds API endpoints for working with incident actions, with the base path `/api/incidents/<incident pk>/actions`:

* `GET` lists actions for a particular incident
* `GET /<pk>` gets a single action
* `POST` creates a new action for that incident
* `PUT /<pk>` updates an action
* `DELETE /<pk>` deletes an action

Currently the DELETE is a "hard delete", i.e. the item actually gets removed from the DB. It wouldn't be too difficult to change this to a "soft delete", i.e. an admin could go back and recover an action, but I didn't think we'd need this right now 👍 