### PR TITLE
Periodically remind incident lead to close incident

### DIFF
--- a/response/slack/decorators/incident_notification.py
+++ b/response/slack/decorators/incident_notification.py
@@ -1,11 +1,8 @@
-import time
-import requests
 import logging
 
 from datetime import datetime
 
 from response.core.models import Incident
-from response.slack.models.comms_channel import CommsChannel
 from response.slack.models.notification import Notification
 
 logger = logging.getLogger(__name__)
@@ -62,7 +59,8 @@ def recurring_notification(interval_mins, max_notifications=1):
 
 
 def handle_notifications():
-    # notifications are only sent to open incidents with comms channels
+
+    # Only notify open incidents with a comms channel
     open_incidents = Incident.objects.filter(
         end_time__isnull=True,
         commschannel__incident__isnull=False

--- a/response/slack/decorators/incident_notification.py
+++ b/response/slack/decorators/incident_notification.py
@@ -82,8 +82,8 @@ def handle_notifications():
                 if mins_since_last_notify >= handler.interval_mins:
                     try:
                         handler.callback(incident)
-                    except:
-                        logger.error(f"Error calling notification handler {handler}")
+                    except Exception as e:
+                        logger.error(f"Error calling notification handler {handler}: {e}")
 
                     notification.time = datetime.now()
                     notification.repeat_count = notification.repeat_count + 1
@@ -96,8 +96,8 @@ def handle_notifications():
                 if mins_since_started >= handler.interval_mins:
                     try:
                         handler.callback(incident)
-                    except:
-                        logger.error(f"Error calling notification handler {handler}")
+                    except Exception as e:
+                        logger.error(f"Error calling notification handler {handler}: {e}")
 
                     notification = Notification(
                         incident=incident,

--- a/response/slack/incident_notifications.py
+++ b/response/slack/incident_notifications.py
@@ -8,7 +8,8 @@ def remind_severity(incident: Incident):
     try:
         comms_channel = CommsChannel.objects.get(incident=incident)
         if not incident.severity:
-            comms_channel.post_in_channel("🌤️ This incident doesn't have a severity.  Please set one with `@incident severity ...`")
+            comms_channel.post_in_channel(
+                "🌤️ This incident doesn't have a severity. Please set one with `@incident severity ...`")
     except CommsChannel.DoesNotExist:
         pass
 
@@ -18,15 +19,19 @@ def remind_incident_lead(incident: Incident):
     try:
         comms_channel = CommsChannel.objects.get(incident=incident)
         if not incident.lead:
-            comms_channel.post_in_channel("👩‍🚒 This incident hasn't got a lead.  Please set one with `@incident lead ...`")
+            comms_channel.post_in_channel(
+                "👩‍🚒 This incident hasn't got a lead. Please set one with `@incident lead ...`")
     except CommsChannel.DoesNotExist:
         pass
 
-@recurring_notification(interval_mins=720, max_notifications=6)
+
+@recurring_notification(interval_mins=1440, max_notifications=6)
 def remind_close_incident(incident: Incident):
     try:
         comms_channel = CommsChannel.objects.get(incident=incident)
         if not incident.is_closed():
-            comms_channel.post_in_channel(":timer_clock: This incident has been running a long time.  Can it be closed now?  Remember to pin important messages in order to create the timeline.")
+            comms_channel.post_in_channel(
+                ":timer_clock: This incident has been running a long time."
+                " Can it be closed now?  Remember to pin important messages in order to create the timeline.")
     except CommsChannel.DoesNotExist:
         pass


### PR DESCRIPTION
When an incident is opened, the lead (or reporter if one is not assigned)
will be reminded to close the incident after 24 hours, up to 5 times.

Weekends are filtered out.

It's a bit tricky to test this without refactoring dependencies/side effects
from the notification functions, but it's a small enough change that we
probably don't need to.