### PR TITLE
Add "is_closed" field to /api/incidents

### DIFF
--- a/response/core/serializers.py
+++ b/response/core/serializers.py
@@ -65,6 +65,7 @@ class IncidentSerializer(serializers.ModelSerializer):
             "comms_channel",
             "end_time",
             "impact",
+            "is_closed",
             "lead",
             "pk",
             "report",

--- a/tests/api/test_incidents.py
+++ b/tests/api/test_incidents.py
@@ -18,6 +18,7 @@ def assert_incident_response(incident):
     assert incident["report_time"]
 
     assert "end_time" in incident  # end_time can be null for open incidents
+    assert "is_closed" in incident # this can be false
     assert incident["impact"]
     assert incident["report"]
     assert incident["start_time"]


### PR DESCRIPTION
This is a little redundant (since currently `is_closed = end_time == null`), but it gives us the ability to change this definition in future