### PR TITLE
Nudge incident lead to complete a report on close

### DIFF
--- a/response/slack/incident_commands.py
+++ b/response/slack/incident_commands.py
@@ -6,6 +6,7 @@ from response.slack.decorators import incident_command, get_help
 from response.slack.client import SlackError, reference_to_id
 from datetime import datetime
 
+
 @incident_command(['help'], helptext='Display a list of commands and usage')
 def send_help_text(incident: Incident, user_id: str, message: str):
     return True, get_help()

--- a/response/slack/signals.py
+++ b/response/slack/signals.py
@@ -1,11 +1,12 @@
+from urllib.parse import urljoin
+
 from django.db.models.signals import post_save
-from django.core.signals import request_finished
 from django.dispatch import receiver
+from django.conf import settings
+from django.urls import reverse
 
 from response.core.models import Incident
 from response.slack.models import HeadlinePost
-
-from time import sleep
 
 
 @receiver(post_save, sender=Incident)
@@ -26,6 +27,22 @@ def update_headline_after_incident_save(sender, instance, **kwargs):
         headline_post = HeadlinePost.objects.create_headline_post(
             incident=instance
         )
+
+
+@receiver(post_save, sender=Incident)
+def prompt_incident_report(sender, instance: Incident, **kwargs):
+    """
+    Prompt incident lead to complete a report when an incident is closed.
+    """
+
+    if instance.is_closed():
+        user_to_notify = instance.lead or instance.reporter
+        doc_url = urljoin(
+            settings.SITE_URL,
+            reverse('incident_doc', kwargs={'incident_id': instance.pk})
+        )
+        settings.SLACK_CLIENT.send_message(
+            user_to_notify.external_id, f"👋 Don't forget to fill out an incident report here: {doc_url}")
 
 
 @receiver(post_save, sender=HeadlinePost)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,9 +8,9 @@ from django.conf import settings
 import pytest
 from unittest.mock import MagicMock
 
-from response.slack import dialog_builder, slack_utils, block_kit
 from response.slack.authentication import generate_signature
 from response.slack.client import SlackClient
+
 
 @pytest.fixture(autouse=True)
 def mock_slack(monkeypatch):


### PR DESCRIPTION
Uses a pre_save signal to determine if the incident has been closed by this operation (otherwise, if an incident is edited after close, this will fire again).