### PR TITLE
Include Slack channel name in /api/incidents response

### DIFF
--- a/response/core/serializers.py
+++ b/response/core/serializers.py
@@ -49,7 +49,7 @@ class ActionSerializer(serializers.ModelSerializer):
 class CommsChannelSerializer(serializers.ModelSerializer):
     class Meta:
         model = CommsChannel
-        fields = ("channel_id",)
+        fields = ("channel_id", "channel_name")
 
 
 class IncidentSerializer(serializers.ModelSerializer):

--- a/response/slack/client.py
+++ b/response/slack/client.py
@@ -43,6 +43,19 @@ class SlackClient(object):
                 return user["id"]
         raise SlackError(f"User '{name}' not found")
 
+    def get_channel_name(self, id):
+        logger.info(f"Getting channel name for {id}")
+        try:
+            response = self.api_call(
+                "conversations.info",
+                channel=id,
+            )
+            return response["channel"]["name"]
+        except SlackError as e:
+            if e.slack_error == "channel_not_found":
+                return None
+            raise
+
     def get_channel_id(self, name):
         logger.info(f"Getting channel ID for {name}")
         next_cursor = None

--- a/response/slack/client.py
+++ b/response/slack/client.py
@@ -44,7 +44,6 @@ class SlackClient(object):
         raise SlackError(f"User '{name}' not found")
 
     def get_channel_name(self, id):
-        logger.info(f"Getting channel name for {id}")
         try:
             response = self.api_call(
                 "conversations.info",

--- a/response/slack/models/comms_channel.py
+++ b/response/slack/models/comms_channel.py
@@ -51,5 +51,8 @@ class CommsChannel(models.Model):
     def rename(self, new_name):
         settings.SLACK_CLIENT.rename_channel(self.channel_id, new_name)
 
+    def channel_name(self):
+        return settings.SLACK_CLIENT.get_channel_name(self.channel_id)
+
     def __str__(self):
         return self.incident.report

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,7 @@ from response.slack.client import SlackClient
 @pytest.fixture(autouse=True)
 def mock_slack(monkeypatch):
     mock_slack = MagicMock(spec=SlackClient(""))
+    mock_slack.get_channel_name.return_value = "#inc-test-channel"
     mock_slack.send_or_update_message_block.return_value = {
         "ok": True,
         "ts": 1234,


### PR DESCRIPTION
This queries the Slack API for the channel name of a particular ID. This
seems to return pretty quickly, as long as the API response isn't too
long - we can optimise and add caching later on if this becomes a
problem