### PR TITLE
Update Dockerfile.response

### DIFF
--- a/demo/Dockerfile.response
+++ b/demo/Dockerfile.response
@@ -1,7 +1,8 @@
-FROM python:3.7
+FROM python:3.7-slim
 
-RUN apt-get update && apt-get install -y \
-    netcat
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    netcat \
+    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 COPY requirements.txt /app


### PR DESCRIPTION
This reduces the final response image size from ~1gb to ~230mb by using the `slim` python image and removing unnecessary apt caching.