### PR TITLE
Expose timeline event ID in TimelineEvent endpoint

### DIFF
--- a/response/core/serializers.py
+++ b/response/core/serializers.py
@@ -13,8 +13,8 @@ class ExternalUserSerializer(serializers.ModelSerializer):
 class TimelineEventSerializer(serializers.ModelSerializer):
     class Meta:
         model = TimelineEvent
-        fields = ("pk", "timestamp", "text", "event_type", "metadata")
-        read_only_fields = ("pk",)
+        fields = ("id", "timestamp", "text", "event_type", "metadata")
+        read_only_fields = ("id",)
 
 
 class ActionSerializer(serializers.ModelSerializer):

--- a/response/core/serializers.py
+++ b/response/core/serializers.py
@@ -13,7 +13,8 @@ class ExternalUserSerializer(serializers.ModelSerializer):
 class TimelineEventSerializer(serializers.ModelSerializer):
     class Meta:
         model = TimelineEvent
-        fields = ("timestamp", "text", "event_type", "metadata")
+        fields = ("pk", "timestamp", "text", "event_type", "metadata")
+        read_only_fields = ("pk",)
 
 
 class ActionSerializer(serializers.ModelSerializer):

--- a/response/core/serializers.py
+++ b/response/core/serializers.py
@@ -22,8 +22,8 @@ class ActionSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Action
-        fields = ("pk", "details", "done", "user")
-        read_only_fields = ("pk",)
+        fields = ("id", "details", "done", "user")
+        read_only_fields = ("id",)
 
     def create(self, validated_data):
         user = ExternalUser.objects.get(
@@ -68,7 +68,7 @@ class IncidentSerializer(serializers.ModelSerializer):
             "impact",
             "is_closed",
             "lead",
-            "pk",
+            "id",
             "report",
             "report_time",
             "reporter",

--- a/tests/api/test_actions.py
+++ b/tests/api/test_actions.py
@@ -108,7 +108,7 @@ def update_action(arf, api_user, incident_id, action_data):
     force_authenticate(req, user=api_user)
 
     return IncidentActionViewSet.as_view({"put": "update"})(
-        req, incident_pk=incident_id, pk=action_data["pk"]
+        req, incident_pk=incident_id, pk=action_data["id"]
     )
 
 

--- a/tests/api/test_timeline.py
+++ b/tests/api/test_timeline.py
@@ -57,6 +57,7 @@ def test_list_actions_by_incident(arf, api_user):
         assert event["timestamp"]
         assert event["text"]
         assert event["event_type"]
+        assert event["id"]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
So that frontends consuming this endpoint can know which ID to update! 

Also, change the `pk` field to `id` so it's a bit nicer in the API.