### PR TITLE
Improve Auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ MARKDOWN_FILTER_WHITELIST_STYLES = [
     "vertical-align", "text-align", "border-style", "border-width", "float",
     "margin", "margin-bottom", "margin-left", "margin-right", "margin-top",
 ]
+
+RESPONSE_LOGIN_REQUIRED = True
 ```
 
 In `urls.py`, add the following to `urlpatterns` (you may also need to import `include`):

--- a/README.md
+++ b/README.md
@@ -57,7 +57,6 @@ STATIC_ROOT = "static"
 REST_FRAMEWORK = {
     "PAGE_SIZE": 100,
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.LimitOffsetPagination",
-    "DEFAULT_PERMISSION_CLASSES": ["rest_framework.permissions.IsAuthenticated"],
     "DEFAULT_PERMISSION_CLASSES": [
         "rest_framework.permissions.IsAuthenticated",
     ],

--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ REST_FRAMEWORK = {
     "PAGE_SIZE": 100,
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.LimitOffsetPagination",
     "DEFAULT_PERMISSION_CLASSES": ["rest_framework.permissions.IsAuthenticated"],
+    "DEFAULT_PERMISSION_CLASSES": [
+        "rest_framework.permissions.IsAuthenticated",
+    ],
 }
 #
 

--- a/demo/demo/settings/base.py
+++ b/demo/demo/settings/base.py
@@ -139,8 +139,8 @@ STATIC_ROOT = 'static'
 REST_FRAMEWORK = {
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',
     'PAGE_SIZE': 100,
-    # Use Django's standard `django.contrib.auth` permissions,
-    # or allow read-only access for unauthenticated users.
+    # Use Django's standard `django.contrib.auth` permissions.
+    # Change to IsAuthenticatedOrReadOnly for read-only unauthenticated access.
     'DEFAULT_PERMISSION_CLASSES': [
         'rest_framework.permissions.IsAuthenticated'
     ]

--- a/demo/demo/settings/base.py
+++ b/demo/demo/settings/base.py
@@ -140,7 +140,9 @@ REST_FRAMEWORK = {
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',
     'PAGE_SIZE': 100,
     # Use Django's standard `django.contrib.auth` permissions.
-    # Change to IsAuthenticatedOrReadOnly for read-only unauthenticated access.
+    # Change to IsAuthenticatedOrReadOnly for read-only unauthenticated access
+    # or see the Django Rest Framework docs for more options:
+    # https://www.django-rest-framework.org/api-guide/permissions/#setting-the-permission-policy
     'DEFAULT_PERMISSION_CLASSES': [
         'rest_framework.permissions.IsAuthenticated'
     ]

--- a/response/apps.py
+++ b/response/apps.py
@@ -1,4 +1,5 @@
 from django.apps import AppConfig
+from django.conf import settings as site_settings
 
 
 class ResponseConfig(AppConfig):
@@ -12,3 +13,9 @@ class ResponseConfig(AppConfig):
                             incident_commands,
                             incident_notifications,
                             dialog_handlers)
+
+        site_settings.RESPONSE_LOGIN_REQUIRED = getattr(
+            site_settings,
+            'RESPONSE_LOGIN_REQUIRED',
+            True,
+        )

--- a/response/decorators.py
+++ b/response/decorators.py
@@ -1,0 +1,18 @@
+from django.conf import settings
+from django.contrib.auth import REDIRECT_FIELD_NAME
+from django.contrib.auth.decorators import user_passes_test
+
+
+def response_login_required(function=None, redirect_field_name=REDIRECT_FIELD_NAME, login_url=None):
+    """
+    Re-implementation of Django's login_required decorator to extend with
+    support for allowing anonymous viewing if `RESPONSE_LOGIN_REQUIRED` is True.
+    """
+    actual_decorator = user_passes_test(
+        lambda u: u.is_authenticated or not settings.RESPONSE_LOGIN_REQUIRED,
+        login_url=login_url,
+        redirect_field_name=redirect_field_name
+    )
+    if function:
+        return actual_decorator(function)
+    return actual_decorator

--- a/response/ui/views.py
+++ b/response/ui/views.py
@@ -3,8 +3,10 @@ from django.http import HttpRequest, HttpResponse, Http404
 
 from response.core.models import Incident
 from response.slack.models import PinnedMessage, UserStats
+from response.decorators import response_login_required
 
 
+@response_login_required
 def incident_doc(request: HttpRequest, incident_id: str):
 
     try:

--- a/tests/api/test_incidents.py
+++ b/tests/api/test_incidents.py
@@ -187,3 +187,24 @@ def test_update_incident_lead(arf, api_user):
 
     new_incident = Incident.objects.get(pk=incident.pk)
     assert new_incident.lead == new_lead
+
+
+def test_cannot_access_incident_logged_out_if_configured(client, db, settings):
+    settings.RESPONSE_LOGIN_REQUIRED = True
+
+    incident = IncidentFactory()
+
+    response = client.get(reverse("incident_doc", args=(incident.pk,)))
+
+    assert response.status_code == 302
+    assert response['location'].startswith(settings.LOGIN_URL)
+
+
+def test_can_access_incident_logged_out_if_configured(client, db, settings):
+    settings.RESPONSE_LOGIN_REQUIRED = False
+
+    incident = IncidentFactory()
+
+    response = client.get(reverse("incident_doc", args=(incident.pk,)))
+
+    assert response.status_code == 200


### PR DESCRIPTION
This PR introduces on-by-default authentication for the views owned by `response`, plus updates the documentation to recommend a Django Rest Framework setup that is authenticated.