### PR TITLE
Use incrementing IDs for unique fields in factories

### DIFF
--- a/tests/factories/user.py
+++ b/tests/factories/user.py
@@ -12,7 +12,7 @@ class UserFactory(factory.DjangoModelFactory):
     class Meta:
         model = User
 
-    username = factory.LazyFunction(faker.user_name)
+    username = factory.Sequence(lambda i: faker.user_name() + str(i))
     password = factory.LazyFunction(faker.password)
 
 
@@ -22,5 +22,5 @@ class ExternalUserFactory(factory.DjangoModelFactory):
 
     app_id = "slack"
     display_name = factory.LazyFunction(faker.name)
-    external_id = factory.LazyFunction(lambda: "U" + faker.word())
+    external_id = factory.Sequence(lambda i: "U" + str(i).zfill(5))
     owner = factory.SubFactory("tests.factories.UserFactory")


### PR DESCRIPTION
This prevents cases where test can fail due to duplicated data, which has been hit in local development