### PR TITLE
Add timeline events on incident updates

### DIFF
--- a/response/core/models/timeline.py
+++ b/response/core/models/timeline.py
@@ -23,3 +23,24 @@ class TimelineEvent(models.Model):
         help_text="Additional fields that can be added by other event types", null=True
     )
 
+
+def add_incident_update_event(incident, update_type, old_value, new_value,
+                              text, timestamp=None):
+
+    if not timestamp:
+        timestamp = datetime.now()
+
+    timeline_event = TimelineEvent(
+        incident=incident,
+        timestamp=timestamp,
+        text=text,
+        event_type="incident_update",
+        metadata={
+            "update_type": update_type,
+            "old_value": old_value,
+            "new_value": new_value,
+        },
+    )
+    timeline_event.save()
+
+

--- a/response/slack/signals.py
+++ b/response/slack/signals.py
@@ -5,7 +5,8 @@ from django.dispatch import receiver
 from django.conf import settings
 from django.urls import reverse
 
-from response.core.models import Incident
+from response.core.models import Incident, add_incident_update_event
+from response.core.serializers import ExternalUserSerializer
 from response.slack.models import HeadlinePost
 
 
@@ -18,15 +19,11 @@ def update_headline_after_incident_save(sender, instance, **kwargs):
 
     """
     try:
-        headline_post = HeadlinePost.objects.get(
-            incident=instance
-        )
+        headline_post = HeadlinePost.objects.get(incident=instance)
         headline_post.update_in_slack()
 
     except HeadlinePost.DoesNotExist:
-        headline_post = HeadlinePost.objects.create_headline_post(
-            incident=instance
-        )
+        headline_post = HeadlinePost.objects.create_headline_post(incident=instance)
 
 
 @receiver(pre_save, sender=Incident)
@@ -45,10 +42,12 @@ def prompt_incident_report(sender, instance: Incident, **kwargs):
         user_to_notify = instance.lead or instance.reporter
         doc_url = urljoin(
             settings.SITE_URL,
-            reverse('incident_doc', kwargs={'incident_id': instance.pk})
+            reverse("incident_doc", kwargs={"incident_id": instance.pk}),
         )
         settings.SLACK_CLIENT.send_message(
-            user_to_notify.external_id, f"👋 Don't forget to fill out an incident report here: {doc_url}")
+            user_to_notify.external_id,
+            f"👋 Don't forget to fill out an incident report here: {doc_url}",
+        )
 
 
 @receiver(post_save, sender=HeadlinePost)
@@ -58,3 +57,114 @@ def update_headline_after_save(sender, instance, **kwargs):
 
     """
     instance.update_in_slack()
+
+
+@receiver(pre_save, sender=Incident)
+def add_timeline_events(sender, instance: Incident, **kwargs):
+    try:
+        prev_state = Incident.objects.get(pk=instance.pk)
+    except Incident.DoesNotExist:
+        # Incident hasn't been saved yet, nothing to do here.
+        return
+
+    if prev_state.lead != instance.lead:
+        update_incident_lead_event(prev_state, instance)
+
+    if prev_state.report != instance.report:
+        update_incident_report_event(prev_state, instance)
+
+    if prev_state.summary != instance.summary:
+        update_incident_summary_event(prev_state, instance)
+
+    if prev_state.impact != instance.impact:
+        update_incident_impact_event(prev_state, instance)
+
+    if prev_state.severity != instance.severity:
+        update_incident_severity_event(prev_state, instance)
+
+def update_incident_lead_event(prev_state, instance):
+    old_lead = None
+    if prev_state.lead:
+        old_lead = ExternalUserSerializer(prev_state.lead).data
+
+    new_lead = None
+    if instance.lead:
+
+        new_lead = ExternalUserSerializer(instance.lead).data
+
+    if prev_state.lead:
+        if instance.lead:
+            text = f"Incident lead changed from {prev_state.lead.display_name} to {instance.lead.display_name}"
+        else:
+            text = f"{prev_state.lead.display_name} was removed as incident lead"
+
+    else:
+        text = f"{instance.lead.display_name} was added as incident lead"
+
+    add_incident_update_event(
+        incident=instance,
+        update_type="incident_lead",
+        text=text,
+        old_value=old_lead,
+        new_value=new_lead,
+    )
+
+
+def update_incident_report_event(prev_state, instance):
+    add_incident_update_event(
+        incident=instance,
+        update_type="incident_report",
+        text=f'Incident report updated from "{prev_state.report}" to "{instance.report}"',
+        old_value=prev_state.report,
+        new_value=instance.report,
+    )
+
+
+def update_incident_summary_event(prev_state, instance):
+    if prev_state.summary:
+        text = (
+            f'Incident summary updated from "{prev_state.summary}" to "{instance.summary}"',
+        )
+    else:
+        text = f'Incident summary added: "{instance.summary}"'
+
+    add_incident_update_event(
+        incident=instance,
+        update_type="incident_summary",
+        text=text,
+        old_value=prev_state.summary,
+        new_value=instance.summary,
+    )
+
+
+def update_incident_impact_event(prev_state, instance):
+    if prev_state.impact:
+        text = (
+            f'Incident impact updated from "{prev_state.impact}" to "{instance.impact}"',
+        )
+    else:
+        text = f'Incident impact added: "{instance.impact}"'
+
+    add_incident_update_event(
+        incident=instance,
+        update_type="incident_impact",
+        text=text,
+        old_value=prev_state.impact,
+        new_value=instance.impact,
+    )
+
+def update_incident_severity_event(prev_state, instance):
+    if prev_state.severity:
+        text = (
+            f'Incident severity updated from {prev_state.severity_text()} to {instance.severity_text()}',
+        )
+    else:
+        text = f'Incident severity set to {instance.severity_text()}'
+
+    add_incident_update_event(
+        incident=instance,
+        update_type="incident_impact",
+        text=text,
+        old_value={"id": prev_state.severity, "text": prev_state.severity_text() if prev_state else ""},
+        new_value={"id": instance.severity, "text": instance.severity_text()},
+    )

--- a/response/slack/signals.py
+++ b/response/slack/signals.py
@@ -89,7 +89,6 @@ def update_incident_lead_event(prev_state, instance):
 
     new_lead = None
     if instance.lead:
-
         new_lead = ExternalUserSerializer(instance.lead).data
 
     if prev_state.lead:

--- a/tests/timeline/test_timeline_events.py
+++ b/tests/timeline/test_timeline_events.py
@@ -1,0 +1,72 @@
+import random
+
+import pytest
+from faker import Factory
+from response.core.models import TimelineEvent
+
+from tests.factories import ExternalUserFactory, IncidentFactory
+
+faker = Factory.create()
+
+
+@pytest.mark.django_db
+def test_update_incident_lead():
+    incident = IncidentFactory.create()
+    new_lead = ExternalUserFactory.create()
+
+    incident.lead = new_lead
+    incident.save()
+
+    event = TimelineEvent.objects.get(incident=incident, event_type="incident_update")
+    assert event.metadata["new_value"]["display_name"] == new_lead.display_name
+
+
+@pytest.mark.django_db
+def test_update_incident_report():
+    incident = IncidentFactory.create()
+    new_report = faker.paragraph(nb_sentences=3, variable_nb_sentences=True)
+
+    incident.report = new_report
+    incident.save()
+
+    event = TimelineEvent.objects.get(incident=incident, event_type="incident_update")
+    assert event.metadata["new_value"] == new_report
+
+
+@pytest.mark.django_db
+def test_update_incident_summary():
+    incident = IncidentFactory.create()
+    new_summary = faker.paragraph(nb_sentences=3, variable_nb_sentences=True)
+
+    incident.summary = new_summary
+    incident.save()
+
+    event = TimelineEvent.objects.get(incident=incident, event_type="incident_update")
+    assert event.metadata["new_value"] == new_summary
+
+
+@pytest.mark.django_db
+def test_update_incident_impact():
+    incident = IncidentFactory.create()
+    new_impact = faker.paragraph(nb_sentences=1)
+
+    incident.impact = new_impact
+    incident.save()
+
+    event = TimelineEvent.objects.get(incident=incident, event_type="incident_update")
+    assert event.metadata["new_value"] == new_impact
+
+
+@pytest.mark.django_db
+def test_update_incident_severity():
+    incident = IncidentFactory.create()
+    new_severity = str(random.randint(1, 4))
+
+    incident.severity = new_severity
+    incident.save()
+
+    event = TimelineEvent.objects.get(incident=incident, event_type="incident_update")
+    assert event.metadata["new_value"] == {
+        "id": new_severity,
+        "text": incident.severity_text(),
+    }


### PR DESCRIPTION
This populates the timeline when key fields in an incident are updated,
e.g. "Incident lead was changed from Barry to Mary".