### PR TITLE
api: return timeline event metadata as a dict type, not string

### DIFF
--- a/response/core/serializers.py
+++ b/response/core/serializers.py
@@ -11,6 +11,7 @@ class ExternalUserSerializer(serializers.ModelSerializer):
 
 
 class TimelineEventSerializer(serializers.ModelSerializer):
+    metadata = serializers.JSONField(allow_null=True)
     class Meta:
         model = TimelineEvent
         fields = ("id", "timestamp", "text", "event_type", "metadata")

--- a/tests/api/test_timeline.py
+++ b/tests/api/test_timeline.py
@@ -37,7 +37,7 @@ def test_create_timeline_event(arf, api_user):
     )
 
 
-def test_list_actions_by_incident(arf, api_user):
+def test_list_timeline_events_by_incident(arf, api_user):
     incident = IncidentFactory.create()
 
     req = arf.get(
@@ -58,6 +58,9 @@ def test_list_actions_by_incident(arf, api_user):
         assert event["text"]
         assert event["event_type"]
         assert event["id"]
+        if event["event_type"] != "text":
+            assert event["metadata"]
+            assert type(event["metadata"]) == dict
 
 
 @pytest.mark.parametrize(

--- a/tests/factories/timeline.py
+++ b/tests/factories/timeline.py
@@ -1,3 +1,4 @@
+import random
 import factory
 from faker import Factory
 
@@ -7,16 +8,40 @@ from .user import ExternalUserFactory
 
 faker = Factory.create()
 
+
 class TimelineEventFactory(factory.DjangoModelFactory):
     class Meta:
         model = TimelineEvent
 
-    incident = factory.SubFactory('tests.factories.IncidentFactory')
+    incident = factory.SubFactory("tests.factories.IncidentFactory")
 
     timestamp = factory.LazyFunction(
         lambda: faker.date_time_between(start_date="-3d", end_date="now", tzinfo=None)
     )
     text = factory.LazyFunction(
-        lambda: faker.paragraph(nb_sentences=5, variable_nb_sentences=True)
+        lambda: faker.paragraph(nb_sentences=3, variable_nb_sentences=True)
     )
-    event_type = "text"
+    event_type = factory.LazyFunction(
+        lambda: random.choice(["text", "slack_pin", "incident_update"])
+    )
+
+    @factory.lazy_attribute
+    def metadata(self):
+        if self.event_type == "text":
+            return None
+        elif self.event_type == "slack_pin":
+            return {
+                "author": {"display_name": "foo"},
+                "message_ts": "12345679.0",
+                "channel_id": "C12345",
+            }
+        elif self.event_type == "incident_update":
+            return {
+                "update_type": "summary",
+                "old_value": faker.paragraph(
+                    nb_sentences=3, variable_nb_sentences=True
+                ),
+                "new_value": faker.paragraph(
+                    nb_sentences=3, variable_nb_sentences=True
+                ),
+            }

--- a/tests/timeline/test_timeline_events.py
+++ b/tests/timeline/test_timeline_events.py
@@ -17,7 +17,9 @@ def test_update_incident_lead():
     incident.lead = new_lead
     incident.save()
 
-    event = TimelineEvent.objects.get(incident=incident, event_type="incident_update")
+    event = TimelineEvent.objects.filter(
+        incident=incident, event_type="incident_update"
+    ).last()
     assert event.metadata["new_value"]["display_name"] == new_lead.display_name
 
 
@@ -29,7 +31,9 @@ def test_update_incident_report():
     incident.report = new_report
     incident.save()
 
-    event = TimelineEvent.objects.get(incident=incident, event_type="incident_update")
+    event = TimelineEvent.objects.filter(
+        incident=incident, event_type="incident_update"
+    ).last()
     assert event.metadata["new_value"] == new_report
 
 
@@ -41,7 +45,9 @@ def test_update_incident_summary():
     incident.summary = new_summary
     incident.save()
 
-    event = TimelineEvent.objects.get(incident=incident, event_type="incident_update")
+    event = TimelineEvent.objects.filter(
+        incident=incident, event_type="incident_update"
+    ).last()
     assert event.metadata["new_value"] == new_summary
 
 
@@ -53,7 +59,9 @@ def test_update_incident_impact():
     incident.impact = new_impact
     incident.save()
 
-    event = TimelineEvent.objects.get(incident=incident, event_type="incident_update")
+    event = TimelineEvent.objects.filter(
+        incident=incident, event_type="incident_update"
+    ).last()
     assert event.metadata["new_value"] == new_impact
 
 
@@ -65,7 +73,9 @@ def test_update_incident_severity():
     incident.severity = new_severity
     incident.save()
 
-    event = TimelineEvent.objects.get(incident=incident, event_type="incident_update")
+    event = TimelineEvent.objects.filter(
+        incident=incident, event_type="incident_update"
+    ).last()
     assert event.metadata["new_value"] == {
         "id": new_severity,
         "text": incident.severity_text(),


### PR DESCRIPTION
This fixes another regression. When we changed the JSONField, the
serialization type turned to JSON rendered as a string instead of a
dict. This forces the serializer to return native JSON.

I've also updated the TimelineFactory to generate more types of events - this had the effect of breaking some of the incident update tests (as they only expected a single timeline event of `incident_update` event type to be present), so I've fixed those to retrieve the latest event.