### PR TITLE
Send correct metadata for update type when setting severity in Slack

### DIFF
--- a/response/slack/signals.py
+++ b/response/slack/signals.py
@@ -164,7 +164,7 @@ def update_incident_severity_event(prev_state, instance):
 
     add_incident_update_event(
         incident=instance,
-        update_type="incident_impact",
+        update_type="incident_severity",
         text=text,
         old_value={
             "id": prev_state.severity,


### PR DESCRIPTION
Currently when you set severity using `@incident severity` it stores an event with metadata of type `incident_impact` (presumably a copy and paste error). this changes the event metadata update type to `incident_severity`.