### PR TITLE
Automatically unarchive channels that have been used before

### DIFF
--- a/response/slack/client.py
+++ b/response/slack/client.py
@@ -113,19 +113,11 @@ class SlackClient(object):
 
             for channel in response["channels"]:
                 if channel["name"] == name:
-                    if channel['is_archived'] and auto_unarchive:
-                        self.unarchive_channel(channel['id'])
+                    if channel["is_archived"] and auto_unarchive:
+                        self.unarchive_channel(channel["id"])
                     return channel["id"]
 
         raise SlackError(f"Channel '{name}' not found")
-
-    def unarchive_channel(self, channel_id):
-        response = self.api_call(
-            "channels.unarchive",
-            channel=channel_id,
-        )
-        if not response.get("ok", False):
-            raise SlackError(f"Couldn't unarchive channel {channel_id}")
 
     def get_usergroup_id(self, group_name):
         response = self.api_call("usergroups.list")
@@ -175,7 +167,9 @@ class SlackClient(object):
         )
 
     def unarchive_channel(self, channel_id):
-        return self.api_call("channels.unarchive", channel=channel_id)
+        response = self.api_call("channels.unarchive", channel=channel_id)
+        if not response.get("ok", False):
+            raise SlackError(f"Couldn't unarchive channel {channel_id}")
 
     def send_message(self, channel_id, text, attachments=None, thread_ts=None):
         return self.api_call(

--- a/response/slack/client.py
+++ b/response/slack/client.py
@@ -96,7 +96,7 @@ class SlackClient(object):
         while next_cursor != "":
             response = self.api_call(
                 "channels.list",
-                exclude_archived=True,
+                exclude_archived=not auto_unarchive,
                 exclude_members=True,
                 limit=800,
                 cursor=next_cursor,

--- a/response/slack/client.py
+++ b/response/slack/client.py
@@ -233,6 +233,9 @@ class SlackClient(object):
     def invite_user_to_channel(self, user_id, channel_id):
         return self.api_call("channels.invite", user=user_id, channel=channel_id)
 
+    def join_channel(self, channel_id):
+        return self.api_call("channels.join", name=channel_id)
+
     def leave_channel(self, channel_id):
         return self.api_call("channels.leave", channel=channel_id)
 

--- a/response/slack/models/comms_channel.py
+++ b/response/slack/models/comms_channel.py
@@ -16,13 +16,23 @@ class CommsChannelManager(models.Manager):
         """
         Creates a comms channel in slack, and saves a reference to it in the DB
         """
+        name = f"inc-{100 + incident.pk}"
+
         try:
-            name = f"inc-{100+incident.pk}"
             channel_id = settings.SLACK_CLIENT.get_or_create_channel(
                 name, auto_unarchive=True
             )
         except SlackError as e:
             logger.error(f"Failed to create comms channel {e}")
+            raise
+
+        # If the channel already existed we will need to join it
+        # If we are already in the channel as we created it, then this is a No-Op
+        try:
+            logger.info(f"Joining channel {name}")
+            settings.SLACK_CLIENT.join_channel(name)
+        except SlackError as e:
+            logger.error(f"Failed to join comms channel {e}")
             raise
 
         try:


### PR DESCRIPTION
This is mostly for use in development.  My instance tried to create comms channel #inc-101, but that channel existed already and had been archived, which the app didn't handle.