### PR TITLE
Fix to make description text instead of tuple

### DIFF
--- a/response/slack/signals.py
+++ b/response/slack/signals.py
@@ -156,9 +156,7 @@ def update_incident_impact_event(prev_state, instance):
 
 def update_incident_severity_event(prev_state, instance):
     if prev_state.severity:
-        text = (
-            f"Incident severity updated from {prev_state.severity_text()} to {instance.severity_text()}",
-        )
+        text = f"Incident severity updated from {prev_state.severity_text()} to {instance.severity_text()}"
     else:
         text = f"Incident severity set to {instance.severity_text()}"
 


### PR DESCRIPTION
This appears to have been an error during formatting.