### PR TITLE
Cache CommsChannel channel name

### DIFF
--- a/docs/slack_app_config.md
+++ b/docs/slack_app_config.md
@@ -25,6 +25,7 @@ In the Event Subscriptions page we need to configure the following:
   - `pin_added`
   - `pin_removed`
   - `message.channels`
+  - `channel_rename`
 
 ## Configure interactive components
 

--- a/response/migrations/0009_commschannel_channel_name.py
+++ b/response/migrations/0009_commschannel_channel_name.py
@@ -13,8 +13,7 @@ so that a value is required.
 """
 
 from django.conf import settings
-from django.db import migrations, models, OperationalError
-
+from django.db import OperationalError, migrations, models
 
 from response.slack.client import SlackError
 
@@ -23,7 +22,9 @@ def set_comms_channel_names(apps, schema_editor):
     CommsChannel = apps.get_model("response", "CommsChannel")
     for comms_channel in CommsChannel.objects.all().iterator():
         try:
-            channel_name = settings.SLACK_CLIENT.get_channel_name(comms_channel.channel_id)
+            channel_name = settings.SLACK_CLIENT.get_channel_name(
+                comms_channel.channel_id
+            )
         except SlackError as e:
             raise OperationalError(
                 f"""Error connecting to the Slack API: {str(e)}

--- a/response/migrations/0009_commschannel_channel_name.py
+++ b/response/migrations/0009_commschannel_channel_name.py
@@ -1,0 +1,55 @@
+"""
+This is a slightly more complex migration. This change adds a new CommsChannel
+field to cache the channel name, updating it when the Slack API notifies us of
+a channel rename. For existing CommsChannel in the DB, we need to populate
+the channel_name by connecting to the Slack API.
+
+This applies the migration in three stages. First, we add the new field, but
+make it nullable, so there's no need to set a default. The next step iterates
+over existing CommsChannels, and refreshes the name from the Slack API.
+
+Finally, now that every CommsChannel has a channel_name set, we alter the field
+so that a value is required.
+"""
+
+from django.conf import settings
+from django.db import migrations, models, OperationalError
+
+
+from response.slack.client import SlackError
+
+
+def set_comms_channel_names(apps, schema_editor):
+    CommsChannel = apps.get_model("response", "CommsChannel")
+    for comms_channel in CommsChannel.objects.all().iterator():
+        try:
+            channel_name = settings.SLACK_CLIENT.get_channel_name(comms_channel.channel_id)
+        except SlackError as e:
+            raise OperationalError(
+                f"""Error connecting to the Slack API: {str(e)}
+⚠️  This migration requires access to the Slack API to set CommsChannel.channel_name on existing CommsChannel object. Please make sure that the SLACK_TOKEN environment variable is set to a valid value."""
+            )
+
+        comms_channel.channel_name = channel_name
+        comms_channel.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [("response", "0008_externaluser_email")]
+
+    operations = [
+        migrations.AddField(
+            model_name="commschannel",
+            name="channel_name",
+            field=models.CharField(null=True, max_length=80),
+            preserve_default=False,
+        ),
+        migrations.RunPython(set_comms_channel_names, migrations.RunPython.noop),
+        migrations.AlterField(
+            model_name="commschannel",
+            name="channel_name",
+            field=models.CharField(null=False, max_length=80),
+            preserve_default=False,
+        ),
+    ]

--- a/response/slack/decorators/event_handler.py
+++ b/response/slack/decorators/event_handler.py
@@ -60,7 +60,12 @@ def handle_event(payload):
     if "channel_id" in event:
         channel_id = event["channel_id"]
     elif "channel" in event:
-        channel_id = event["channel"]
+        # even better, on channel_rename events "channel" is actually a dict
+        # with an "id" key 😠
+        if isinstance(event["channel"], dict) and "id" in event["channel"]:
+            channel_id = event["channel"]["id"]
+        else:
+            channel_id = event["channel"]
     else:
         channel_id = None
 

--- a/response/slack/event_handlers.py
+++ b/response/slack/event_handlers.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import re
 
 from response.core.models.incident import Incident
@@ -7,7 +8,9 @@ from response.slack.decorators import (
     handle_keywords,
     slack_event,
 )
-from response.slack.models import PinnedMessage, UserStats
+from response.slack.models import PinnedMessage, UserStats, CommsChannel
+
+logger = logging.getLogger(__name__)
 
 
 def decode_app_mention(payload):
@@ -93,3 +96,12 @@ def handle_pin_removed(incident, payload):
     message_ts = pinned_message["ts"]
 
     PinnedMessage.objects.remove_pin(incident, message_ts)
+
+
+@slack_event("channel_rename")
+def handle_channel_rename(incident, payload):
+    new_name = payload["channel"]["name"]
+    logger.info(f"Renaming channel: {id} to {new_name}")
+    comms_channel = CommsChannel.objects.get(incident=incident)
+    comms_channel.channel_name = new_name
+    comms_channel.save()

--- a/response/slack/event_handlers.py
+++ b/response/slack/event_handlers.py
@@ -8,7 +8,7 @@ from response.slack.decorators import (
     handle_keywords,
     slack_event,
 )
-from response.slack.models import PinnedMessage, UserStats, CommsChannel
+from response.slack.models import CommsChannel, PinnedMessage, UserStats
 
 logger = logging.getLogger(__name__)
 

--- a/response/slack/models/comms_channel.py
+++ b/response/slack/models/comms_channel.py
@@ -49,15 +49,13 @@ class CommsChannel(models.Model):
     objects = CommsChannelManager()
     incident = models.ForeignKey(Incident, on_delete=models.CASCADE)
     channel_id = models.CharField(max_length=20, null=False)
+    channel_name = models.CharField(max_length=80, null=False)
 
     def post_in_channel(self, message: str):
         settings.SLACK_CLIENT.send_message(self.channel_id, message)
 
     def rename(self, new_name):
         settings.SLACK_CLIENT.rename_channel(self.channel_id, new_name)
-
-    def channel_name(self):
-        return settings.SLACK_CLIENT.get_channel_name(self.channel_id)
 
     def __str__(self):
         return self.incident.report

--- a/response/slack/models/comms_channel.py
+++ b/response/slack/models/comms_channel.py
@@ -23,6 +23,7 @@ class CommsChannelManager(models.Manager):
             )
         except SlackError as e:
             logger.error(f"Failed to create comms channel {e}")
+            raise
 
         try:
             doc_url = urljoin(
@@ -35,8 +36,11 @@ class CommsChannelManager(models.Manager):
             )
         except SlackError as e:
             logger.error(f"Failed to set channel topic {e}")
+            raise
 
-        comms_channel = self.create(incident=incident, channel_id=channel_id)
+        comms_channel = self.create(
+            incident=incident, channel_id=channel_id, channel_name=name
+        )
         return comms_channel
 
 

--- a/tests/slack/test_channel_rename.py
+++ b/tests/slack/test_channel_rename.py
@@ -1,7 +1,6 @@
 import pytest
 
 from response.slack.event_handlers import handle_channel_rename
-
 from tests.factories import IncidentFactory
 
 

--- a/tests/slack/test_channel_rename.py
+++ b/tests/slack/test_channel_rename.py
@@ -1,0 +1,13 @@
+import pytest
+
+from response.slack.event_handlers import handle_channel_rename
+
+from tests.factories import IncidentFactory
+
+
+@pytest.mark.django_db
+def test_handle_channel_rename(mock_slack):
+    incident = IncidentFactory.create()
+
+    handle_channel_rename(incident, {"channel": {"name": "new-channel-name"}})
+    assert incident.comms_channel().channel_name == "new-channel-name"


### PR DESCRIPTION
Currently any time that `CommsChannel.channel_name` is requested, we go and fetch it from the Slack API. This leads to rate limiting issues when listing a large number of incidents, as Response will call the Slack API for every single incident.

This change caches the channel name in a new model field, updating it whenever we get a `channel_rename` event from Slack. One complication is that we'd like to backfill this for existing CommsChannels in the database (and make the field non-nullable) - I've written a reasonably complex migration that fetches CommsChannel names and populates the field. This has the unfortunate side-effect of requiring a valid `SLACK_TOKEN` environment variable when running migrations.

TODO:

- [ ] Test this better - especially the Slack API retry/backoff