### PR TITLE
timeline api: make metadata optional

### DIFF
--- a/response/core/serializers.py
+++ b/response/core/serializers.py
@@ -11,7 +11,7 @@ class ExternalUserSerializer(serializers.ModelSerializer):
 
 
 class TimelineEventSerializer(serializers.ModelSerializer):
-    metadata = serializers.JSONField(allow_null=True)
+    metadata = serializers.JSONField(allow_null=True, required=False)
 
     class Meta:
         model = TimelineEvent


### PR DESCRIPTION
The API currently errors with HTTP 400 if we try to create a timeline
event without a metadata tag. This makes the field non-required in the
serializer.