### PR TITLE
core models: sanitize user input

### DIFF
--- a/response/core/models/__init__.py
+++ b/response/core/models/__init__.py
@@ -3,6 +3,7 @@ from .incident import Incident
 from .timeline import TimelineEvent, add_incident_update_event
 from .user_external import ExternalUser
 
+
 __all__ = (
     "Action",
     "Incident",

--- a/response/core/models/__init__.py
+++ b/response/core/models/__init__.py
@@ -3,7 +3,6 @@ from .incident import Incident
 from .timeline import TimelineEvent, add_incident_update_event
 from .user_external import ExternalUser
 
-
 __all__ = (
     "Action",
     "Incident",

--- a/response/core/models/action.py
+++ b/response/core/models/action.py
@@ -2,6 +2,7 @@ from django.db import models
 
 from response.core.models.incident import Incident
 from response.core.models.user_external import ExternalUser
+from response.core.util import sanitize
 
 
 class Action(models.Model):
@@ -17,3 +18,7 @@ class Action(models.Model):
 
     def __str__(self):
         return f"{self.details}"
+
+    def save(self, *args, **kwargs):
+        self.details = sanitize(self.details)
+        super(Action, self).save(*args, **kwargs)

--- a/response/core/models/incident.py
+++ b/response/core/models/incident.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from django.db import models
 
 from response import core, slack
+from response.core.util import sanitize
 from response.core.models.user_external import ExternalUser
 
 
@@ -129,3 +130,9 @@ class Incident(models.Model):
 
     def timeline_events(self):
         return core.models.TimelineEvent.objects.filter(incident=self)
+
+    def save(self, *args, **kwargs):
+        self.impact = sanitize(self.impact)
+        self.report = sanitize(self.report)
+        self.summary = sanitize(self.summary)
+        super(Incident, self).save(*args, **kwargs)

--- a/response/core/models/incident.py
+++ b/response/core/models/incident.py
@@ -3,8 +3,8 @@ from datetime import datetime
 from django.db import models
 
 from response import core, slack
-from response.core.util import sanitize
 from response.core.models.user_external import ExternalUser
+from response.core.util import sanitize
 
 
 class IncidentManager(models.Manager):

--- a/response/core/models/timeline.py
+++ b/response/core/models/timeline.py
@@ -4,6 +4,7 @@ from django.db import models
 from jsonfield import JSONField
 
 from response.core.models.incident import Incident
+from response.core.util import sanitize
 
 EVENT_TYPES = (
     ("text", "Freeform text field"),
@@ -22,6 +23,11 @@ class TimelineEvent(models.Model):
     metadata = JSONField(
         help_text="Additional fields that can be added by other event types", null=True
     )
+
+    def save(self, *args, **kwargs):
+        print(type(self.text))
+        self.text = sanitize(self.text)
+        super(TimelineEvent, self).save(*args, **kwargs)
 
 
 def add_incident_update_event(

--- a/response/core/models/timeline.py
+++ b/response/core/models/timeline.py
@@ -25,7 +25,6 @@ class TimelineEvent(models.Model):
     )
 
     def save(self, *args, **kwargs):
-        print(type(self.text))
         self.text = sanitize(self.text)
         super(TimelineEvent, self).save(*args, **kwargs)
 

--- a/response/core/util.py
+++ b/response/core/util.py
@@ -1,0 +1,11 @@
+import bleach
+import bleach_whitelist
+
+
+def sanitize(string):
+    return bleach.clean(
+        string,
+        tags=bleach_whitelist.markdown_tags,
+        attributes=bleach_whitelist.markdown_attrs,
+        styles=bleach_whitelist.all_styles,
+    )

--- a/response/slack/signals.py
+++ b/response/slack/signals.py
@@ -122,9 +122,7 @@ def update_incident_report_event(prev_state, instance):
 
 def update_incident_summary_event(prev_state, instance):
     if prev_state.summary:
-        text = (
-            f'Incident summary updated from "{prev_state.summary}" to "{instance.summary}"',
-        )
+        text = f'Incident summary updated from "{prev_state.summary}" to "{instance.summary}"'
     else:
         text = f'Incident summary added: "{instance.summary}"'
 
@@ -140,7 +138,7 @@ def update_incident_summary_event(prev_state, instance):
 def update_incident_impact_event(prev_state, instance):
     if prev_state.impact:
         text = (
-            f'Incident impact updated from "{prev_state.impact}" to "{instance.impact}"',
+            f'Incident impact updated from "{prev_state.impact}" to "{instance.impact}"'
         )
     else:
         text = f'Incident impact added: "{instance.impact}"'

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ VERSION = "0.1.10"
 INSTALL_REQUIRES = [
     "Django>=2.2",
     "bleach==3.1.0",
-    "bleach-whitelist>=0.0.11",
+    "bleach-whitelist>=0.0.10",
     "cryptography>=2.7",
     "django-after-response>=0.2.2",
     "django-bootstrap4>=0.0.7",

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ VERSION = "0.1.10"
 INSTALL_REQUIRES = [
     "Django>=2.2",
     "bleach==3.1.0",
+    "bleach-whitelist>=0.0.11",
     "cryptography>=2.7",
     "django-after-response>=0.2.2",
     "django-bootstrap4>=0.0.7",


### PR DESCRIPTION
Currently the API (and Slack app) allows users to enter any text they like for various fields - this has security implications if we end up rendering that text in a UI page down the line. Django UI templating handles this case automatically, but other types of UI consuming the API won't - here we sanitize input (using https://pypi.org/project/bleach/) before it gets saved to the DB.