### PR TITLE
Ensure the severity field is not unset

### DIFF
--- a/response/core/serializers.py
+++ b/response/core/serializers.py
@@ -63,6 +63,9 @@ class IncidentSerializer(serializers.ModelSerializer):
     comms_channel = CommsChannelSerializer(read_only=True)
     action_items = ActionSerializer(read_only=True, many=True)
 
+    # Weirdly, this ensures we can't unset severity
+    severity = serializers.CharField(required=False)
+
     class Meta:
         model = Incident
         fields = (

--- a/response/core/serializers.py
+++ b/response/core/serializers.py
@@ -63,7 +63,11 @@ class IncidentSerializer(serializers.ModelSerializer):
     comms_channel = CommsChannelSerializer(read_only=True)
     action_items = ActionSerializer(read_only=True, many=True)
 
-    # Weirdly, this ensures we can't unset severity
+    # This ensures we can't unset severity
+    # https://www.django-rest-framework.org/api-guide/fields/#required
+    # `required = False` means the field doesn't have to be included when the json request is
+    # deserialised (including creation), and so it remains unchanged (if None, it remains None).
+    # `allow_null` is set to False by default so we still demand a value is given _if_ it's sent in the json.
     severity = serializers.CharField(required=False)
 
     class Meta:

--- a/response/slack/dialog_handlers.py
+++ b/response/slack/dialog_handlers.py
@@ -82,6 +82,9 @@ def edit_incident(
     try:
         incident = Incident.objects.get(pk=state)
 
+        if not severity and incident.severity:
+            raise Exception("Cannot unset severity")
+
         # deliberately update in this way the post_save signal gets sent
         # (required for the headline post to auto update)
         incident.report = report

--- a/tests/api/test_incidents.py
+++ b/tests/api/test_incidents.py
@@ -190,6 +190,29 @@ def test_update_incident_lead(arf, api_user):
     assert new_incident.lead == new_lead
 
 
+def test_cannot_unset_severity(arf, api_user):
+    """
+    Tests that we cannot unset the incident severity
+    """
+
+    incident = IncidentFactory.create()
+    serializer = serializers.IncidentSerializer(incident)
+    updated = serializer.data
+
+    updated["severity"] = None  # unset severity
+
+    req = arf.put(
+        reverse("incident-detail", kwargs={"pk": incident.pk}), updated, format="json"
+    )
+    force_authenticate(req, user=api_user)
+
+    response = IncidentViewSet.as_view({"put": "update"})(req, pk=incident.pk)
+    print(response.rendered_content)
+    assert (
+        response.status_code != 200
+    ), "Got 200 response from API when we expected an error"
+
+
 def test_cannot_access_incident_logged_out_if_configured(client, db, settings):
     settings.RESPONSE_LOGIN_REQUIRED = True
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -184,7 +184,7 @@ def test_edit_incident(post_from_slack_api, mock_slack):
                     "summary": newsummary,
                     "impact": "",
                     "lead": "U123",
-                    "severity": "",
+                    "severity": "1",
                     "incident_type": "",
                 },
                 "state": incident.id,


### PR DESCRIPTION
Once a severity has been set it should not be unset, only ever up or downgraded.