### PR TITLE
Handle None types sent as strings for sanitising with bleach

### DIFF
--- a/response/core/util.py
+++ b/response/core/util.py
@@ -3,9 +3,13 @@ import bleach_whitelist
 
 
 def sanitize(string):
-    return bleach.clean(
-        string,
-        tags=bleach_whitelist.markdown_tags,
-        attributes=bleach_whitelist.markdown_attrs,
-        styles=bleach_whitelist.all_styles,
-    )
+    # bleach doesn't handle None so let's not pass it
+    if string:
+        return bleach.clean(
+            string,
+            tags=bleach_whitelist.markdown_tags,
+            attributes=bleach_whitelist.markdown_attrs,
+            styles=bleach_whitelist.all_styles,
+        )
+
+    return string

--- a/tests/core/util_test.py
+++ b/tests/core/util_test.py
@@ -1,0 +1,18 @@
+from unittest import mock
+
+import pytest
+
+from response.core.util import sanitize
+
+
+def test_sanitise_handles_none():
+    try:
+        sanitize(None)
+    except TypeError:
+        pytest.fail("Unexpected TypeError handling None")
+
+
+def test_sanitise_sends_sends_to_bleach():
+    with mock.patch("bleach.clean", return_value="good text string"):
+        actual = sanitize("bad text string")
+        assert actual == "good text string"


### PR DESCRIPTION
Bleach doesn't seem to handle None by itself, so we shouldn't pass them to it.