### PR TITLE
Store channel name on rename

### DIFF
--- a/response/slack/decorators/headline_post_action.py
+++ b/response/slack/decorators/headline_post_action.py
@@ -29,9 +29,6 @@ def headline_post_action(order=0, func=None):
         SLACK_HEADLINE_POST_ACTION_MAPPINGS[
             order
         ] = SLACK_HEADLINE_POST_ACTION_MAPPINGS.get(order, []) + [fn]
-        logger.info(
-            f"Registering headline post action {fn.__name__} with order {order}"
-        )
         return fn
 
     if func:

--- a/response/slack/incident_commands.py
+++ b/response/slack/incident_commands.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import datetime
 
 from response.core.models import Action, ExternalUser, Incident
@@ -8,6 +9,8 @@ from response.slack.decorators.incident_command import (
     get_help,
 )
 from response.slack.models import CommsChannel
+
+logger = logging.getLogger(__name__)
 
 
 @__default_incident_command(["help"], helptext="Display a list of commands and usage")
@@ -59,6 +62,7 @@ def set_severity(incident: Incident, user_id: str, message: str):
 def rename_incident(incident: Incident, user_id: str, message: str):
     try:
         comms_channel = CommsChannel.objects.get(incident=incident)
+        logger.info(f"Renaming channel to {message}")
         comms_channel.rename(message)
     except SlackError:
         return (

--- a/response/slack/incident_commands.py
+++ b/response/slack/incident_commands.py
@@ -67,7 +67,7 @@ def rename_incident(incident: Incident, user_id: str, message: str):
     except SlackError:
         return (
             True,
-            "👋 Sorry, the channel couldn't be renamed. Make sure that name isn't taken already.",
+            "👋 Sorry, the channel couldn't be renamed. Make sure that name isn't taken already and it's not too long.",
         )
     return True, None
 

--- a/response/slack/models/comms_channel.py
+++ b/response/slack/models/comms_channel.py
@@ -65,7 +65,12 @@ class CommsChannel(models.Model):
         settings.SLACK_CLIENT.send_message(self.channel_id, message)
 
     def rename(self, new_name):
-        settings.SLACK_CLIENT.rename_channel(self.channel_id, new_name)
+        try:
+            settings.SLACK_CLIENT.rename_channel(self.channel_id, new_name)
+            self.channel_name = new_name
+            self.save()
+        except SlackError as e:
+            logger.error(f"Failed to rename channel {self.channel_id} to {new_name}. Error: {e}")
 
     def __str__(self):
         return self.incident.report

--- a/response/slack/models/comms_channel.py
+++ b/response/slack/models/comms_channel.py
@@ -78,6 +78,9 @@ class CommsChannel(models.Model):
                 logger.error(
                     f"Failed to rename channel {self.channel_id} to {new_name}. Error: {e}"
                 )
+                raise e
+        else:
+            logger.info(f"Attempted to rename channel to nothing. No action take.")
 
     def __str__(self):
         return self.incident.report

--- a/response/slack/models/comms_channel.py
+++ b/response/slack/models/comms_channel.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import datetime
 from urllib.parse import urljoin
 
 from django.conf import settings
@@ -16,7 +17,8 @@ class CommsChannelManager(models.Manager):
         """
         Creates a comms channel in slack, and saves a reference to it in the DB
         """
-        name = f"inc-{100 + incident.pk}"
+        time_string = datetime.now().strftime("%b-%e-%H-%M-%S")
+        name = f"inc-{time_string}".lower()
 
         try:
             channel_id = settings.SLACK_CLIENT.get_or_create_channel(
@@ -65,12 +67,17 @@ class CommsChannel(models.Model):
         settings.SLACK_CLIENT.send_message(self.channel_id, message)
 
     def rename(self, new_name):
-        try:
-            settings.SLACK_CLIENT.rename_channel(self.channel_id, new_name)
-            self.channel_name = new_name
-            self.save()
-        except SlackError as e:
-            logger.error(f"Failed to rename channel {self.channel_id} to {new_name}. Error: {e}")
+        if new_name:
+            try:
+                response = settings.SLACK_CLIENT.rename_channel(
+                    self.channel_id, new_name
+                )
+                self.channel_name = response["channel"]["name"]
+                self.save()
+            except SlackError as e:
+                logger.error(
+                    f"Failed to rename channel {self.channel_id} to {new_name}. Error: {e}"
+                )
 
     def __str__(self):
         return self.incident.report


### PR DESCRIPTION
We use the name in the DB rather than making a slow call to the Slack API.
Without this change renamed channels still have their original name stored.