### PR TITLE
Map slack IDs to user/channel in API serializers

### DIFF
--- a/response/core/serializers.py
+++ b/response/core/serializers.py
@@ -1,7 +1,7 @@
 from rest_framework import serializers
 
 from response.core.models import Action, ExternalUser, Incident, TimelineEvent
-from response.slack.client import slack_to_human_readable
+from response.slack.reference_utils import slack_to_human_readable
 from response.slack.models import CommsChannel
 
 

--- a/response/core/serializers.py
+++ b/response/core/serializers.py
@@ -1,6 +1,7 @@
 from rest_framework import serializers
 
 from response.core.models import Action, ExternalUser, Incident, TimelineEvent
+from response.slack.client import slack_to_human_readable
 from response.slack.models import CommsChannel
 
 
@@ -17,6 +18,11 @@ class TimelineEventSerializer(serializers.ModelSerializer):
         model = TimelineEvent
         fields = ("id", "timestamp", "text", "event_type", "metadata")
         read_only_fields = ("id",)
+
+    def to_representation(self, instance):
+        rep = super().to_representation(instance)
+        rep["text"] = slack_to_human_readable(rep["text"])
+        return rep
 
 
 class ActionSerializer(serializers.ModelSerializer):
@@ -49,6 +55,11 @@ class ActionSerializer(serializers.ModelSerializer):
         instance.done = validated_data.get("done", instance.done)
         instance.save()
         return instance
+
+    def to_representation(self, instance):
+        rep = super().to_representation(instance)
+        rep["details"] = slack_to_human_readable(rep["details"])
+        return rep
 
 
 class CommsChannelSerializer(serializers.ModelSerializer):

--- a/response/core/serializers.py
+++ b/response/core/serializers.py
@@ -14,25 +14,30 @@ class ExternalUserSerializer(serializers.ModelSerializer):
 
 class TimelineEventSerializer(serializers.ModelSerializer):
     metadata = serializers.JSONField(allow_null=True, required=False)
+    # Read-only field for displaying human-readable slack references. Updates
+    # should be applied to the text field.
+    text_ui = serializers.SerializerMethodField()
 
     class Meta:
         model = TimelineEvent
-        fields = ("id", "timestamp", "text", "event_type", "metadata")
+        fields = ("id", "timestamp", "text", "event_type", "metadata", "text_ui")
         read_only_fields = ("id",)
 
-    def to_representation(self, instance):
-        rep = super().to_representation(instance)
-        rep["text"] = slack_to_human_readable(rep["text"])
-        rep["text"] = emoji_data_python.replace_colons(rep["text"])
-        return rep
+    def get_text_ui(self, instance):
+        text_ui = slack_to_human_readable(instance.text)
+        text_ui = emoji_data_python.replace_colons(text_ui)
+        return text_ui
 
 
 class ActionSerializer(serializers.ModelSerializer):
     user = ExternalUserSerializer()
+    # Read-only field for displaying human-readable slack references. Updates
+    # should be applied to the details field.
+    details_ui = serializers.SerializerMethodField()
 
     class Meta:
         model = Action
-        fields = ("id", "details", "done", "user")
+        fields = ("id", "details", "done", "user", "details_ui")
         read_only_fields = ("id",)
 
     def create(self, validated_data):
@@ -58,11 +63,10 @@ class ActionSerializer(serializers.ModelSerializer):
         instance.save()
         return instance
 
-    def to_representation(self, instance):
-        rep = super().to_representation(instance)
-        rep["details"] = slack_to_human_readable(rep["details"])
-        rep["details"] = emoji_data_python.replace_colons(rep["details"])
-        return rep
+    def get_details_ui(self, instance):
+        details_ui = slack_to_human_readable(instance.details)
+        details_ui = emoji_data_python.replace_colons(details_ui)
+        return details_ui
 
 
 class CommsChannelSerializer(serializers.ModelSerializer):

--- a/response/core/serializers.py
+++ b/response/core/serializers.py
@@ -1,8 +1,8 @@
 from rest_framework import serializers
 
 from response.core.models import Action, ExternalUser, Incident, TimelineEvent
-from response.slack.reference_utils import slack_to_human_readable
 from response.slack.models import CommsChannel
+from response.slack.reference_utils import slack_to_human_readable
 
 
 class ExternalUserSerializer(serializers.ModelSerializer):

--- a/response/core/serializers.py
+++ b/response/core/serializers.py
@@ -1,3 +1,4 @@
+import emoji_data_python
 from rest_framework import serializers
 
 from response.core.models import Action, ExternalUser, Incident, TimelineEvent
@@ -22,6 +23,7 @@ class TimelineEventSerializer(serializers.ModelSerializer):
     def to_representation(self, instance):
         rep = super().to_representation(instance)
         rep["text"] = slack_to_human_readable(rep["text"])
+        rep["text"] = emoji_data_python.replace_colons(rep["text"])
         return rep
 
 
@@ -59,6 +61,7 @@ class ActionSerializer(serializers.ModelSerializer):
     def to_representation(self, instance):
         rep = super().to_representation(instance)
         rep["details"] = slack_to_human_readable(rep["details"])
+        rep["details"] = emoji_data_python.replace_colons(rep["details"])
         return rep
 
 

--- a/response/slack/client.py
+++ b/response/slack/client.py
@@ -6,6 +6,8 @@ import slackclient
 from django.conf import settings
 from slugify import slugify
 
+from response.slack.reference_utils import reference_to_id
+
 logger = logging.getLogger(__name__)
 
 
@@ -276,12 +278,6 @@ class SlackClient(object):
 
     def dialog_open(self, dialog, trigger_id):
         return self.api_call("dialog.open", trigger_id=trigger_id, dialog=dialog)
-
-
-def reference_to_id(value):
-    """take a string containing <@U123ABCD> refs and extract first match"""
-    m = re.search(r"<@(U[A-Z0-9]+)>", value)
-    return m.group(1) if m else None
 
 
 def user_ref_to_username(value):

--- a/response/slack/client.py
+++ b/response/slack/client.py
@@ -278,12 +278,6 @@ class SlackClient(object):
         return self.api_call("dialog.open", trigger_id=trigger_id, dialog=dialog)
 
 
-def channel_reference(channel_id):
-    if channel_id is None:
-        return None
-    return f"<#{channel_id}>"
-
-
 def user_reference(user_id):
     return f"<@{user_id}>"
 

--- a/response/slack/client.py
+++ b/response/slack/client.py
@@ -278,10 +278,6 @@ class SlackClient(object):
         return self.api_call("dialog.open", trigger_id=trigger_id, dialog=dialog)
 
 
-def user_reference(user_id):
-    return f"<@{user_id}>"
-
-
 def reference_to_id(value):
     """take a string containing <@U123ABCD> refs and extract first match"""
     m = re.search(r"<@(U[A-Z0-9]+)>", value)

--- a/response/slack/client.py
+++ b/response/slack/client.py
@@ -1,11 +1,8 @@
 import logging
-import re
 import time
 
 import slackclient
 from slugify import slugify
-
-from response.slack.reference_utils import user_ref_to_username
 
 logger = logging.getLogger(__name__)
 
@@ -279,8 +276,3 @@ class SlackClient(object):
         return self.api_call("dialog.open", trigger_id=trigger_id, dialog=dialog)
 
 
-def slack_to_human_readable(value):
-    # replace user references (<@U3231FFD>) with usernames (@chrisevans)
-    value = re.sub(r"(<@U[A-Z0-9]+>)", user_ref_to_username, value)
-    value = re.sub(r"(<#C[A-Z0-9]+\|([\-a-zA-Z0-9]+)>)", r"#\2", value)
-    return value

--- a/response/slack/client.py
+++ b/response/slack/client.py
@@ -3,10 +3,9 @@ import re
 import time
 
 import slackclient
-from django.conf import settings
 from slugify import slugify
 
-from response.slack.reference_utils import reference_to_id
+from response.slack.reference_utils import user_ref_to_username
 
 logger = logging.getLogger(__name__)
 
@@ -278,14 +277,6 @@ class SlackClient(object):
 
     def dialog_open(self, dialog, trigger_id):
         return self.api_call("dialog.open", trigger_id=trigger_id, dialog=dialog)
-
-
-def user_ref_to_username(value):
-    """takes a <@U123ABCD> style ref and returns an @username"""
-    # strip the '<@' and '>'
-    user_id = reference_to_id(value.group())
-    user_profile = settings.SLACK_CLIENT.get_user_profile(user_id)
-    return "@" + user_profile["name"] or user_id
 
 
 def slack_to_human_readable(value):

--- a/response/slack/client.py
+++ b/response/slack/client.py
@@ -274,5 +274,3 @@ class SlackClient(object):
 
     def dialog_open(self, dialog, trigger_id):
         return self.api_call("dialog.open", trigger_id=trigger_id, dialog=dialog)
-
-

--- a/response/slack/dialog_handlers.py
+++ b/response/slack/dialog_handlers.py
@@ -6,7 +6,7 @@ from django.conf import settings
 
 from response.core.models import ExternalUser, Incident
 from response.slack.cache import get_user_profile
-from response.slack.client import channel_reference
+from response.slack.reference_utils import channel_reference
 from response.slack.decorators import dialog_handler
 from response.slack.settings import INCIDENT_EDIT_DIALOG, INCIDENT_REPORT_DIALOG
 

--- a/response/slack/dialog_handlers.py
+++ b/response/slack/dialog_handlers.py
@@ -6,8 +6,8 @@ from django.conf import settings
 
 from response.core.models import ExternalUser, Incident
 from response.slack.cache import get_user_profile
-from response.slack.reference_utils import channel_reference
 from response.slack.decorators import dialog_handler
+from response.slack.reference_utils import channel_reference
 from response.slack.settings import INCIDENT_EDIT_DIALOG, INCIDENT_REPORT_DIALOG
 
 logger = logging.getLogger(__name__)

--- a/response/slack/incident_commands.py
+++ b/response/slack/incident_commands.py
@@ -4,12 +4,12 @@ from datetime import datetime
 from response.core.models import Action, ExternalUser, Incident
 from response.slack.cache import get_user_profile
 from response.slack.client import SlackError
-from response.slack.reference_utils import reference_to_id
 from response.slack.decorators.incident_command import (
     __default_incident_command,
     get_help,
 )
 from response.slack.models import CommsChannel
+from response.slack.reference_utils import reference_to_id
 
 logger = logging.getLogger(__name__)
 

--- a/response/slack/incident_commands.py
+++ b/response/slack/incident_commands.py
@@ -3,7 +3,8 @@ from datetime import datetime
 
 from response.core.models import Action, ExternalUser, Incident
 from response.slack.cache import get_user_profile
-from response.slack.client import SlackError, reference_to_id
+from response.slack.client import SlackError
+from response.slack.reference_utils import reference_to_id
 from response.slack.decorators.incident_command import (
     __default_incident_command,
     get_help,

--- a/response/slack/models/headline_post.py
+++ b/response/slack/models/headline_post.py
@@ -8,12 +8,12 @@ from django.urls import reverse
 from response.core.models.incident import Incident
 from response.slack.block_kit import Actions, Button, Divider, Message, Section, Text
 from response.slack.client import SlackError
-from response.slack.reference_utils import channel_reference, user_reference
 from response.slack.decorators.headline_post_action import (
     SLACK_HEADLINE_POST_ACTION_MAPPINGS,
     headline_post_action,
 )
 from response.slack.models.comms_channel import CommsChannel
+from response.slack.reference_utils import channel_reference, user_reference
 
 logger = logging.getLogger(__name__)
 

--- a/response/slack/models/headline_post.py
+++ b/response/slack/models/headline_post.py
@@ -7,7 +7,8 @@ from django.urls import reverse
 
 from response.core.models.incident import Incident
 from response.slack.block_kit import Actions, Button, Divider, Message, Section, Text
-from response.slack.client import SlackError, channel_reference, user_reference
+from response.slack.client import SlackError, user_reference
+from response.slack.reference_utils import channel_reference
 from response.slack.decorators.headline_post_action import (
     SLACK_HEADLINE_POST_ACTION_MAPPINGS,
     headline_post_action,

--- a/response/slack/models/headline_post.py
+++ b/response/slack/models/headline_post.py
@@ -7,8 +7,8 @@ from django.urls import reverse
 
 from response.core.models.incident import Incident
 from response.slack.block_kit import Actions, Button, Divider, Message, Section, Text
-from response.slack.client import SlackError, user_reference
-from response.slack.reference_utils import channel_reference
+from response.slack.client import SlackError
+from response.slack.reference_utils import channel_reference, user_reference
 from response.slack.decorators.headline_post_action import (
     SLACK_HEADLINE_POST_ACTION_MAPPINGS,
     headline_post_action,

--- a/response/slack/reference_utils.py
+++ b/response/slack/reference_utils.py
@@ -2,3 +2,7 @@ def channel_reference(channel_id):
     if channel_id is None:
         return None
     return f"<#{channel_id}>"
+
+
+def user_reference(user_id):
+    return f"<@{user_id}>"

--- a/response/slack/reference_utils.py
+++ b/response/slack/reference_utils.py
@@ -1,0 +1,4 @@
+def channel_reference(channel_id):
+    if channel_id is None:
+        return None
+    return f"<#{channel_id}>"

--- a/response/slack/reference_utils.py
+++ b/response/slack/reference_utils.py
@@ -1,6 +1,6 @@
 import re
 
-from django.conf import settings
+from response.slack import cache
 
 
 def channel_reference(channel_id):
@@ -23,7 +23,7 @@ def user_ref_to_username(value):
     """takes a <@U123ABCD> style ref and returns an @username"""
     # strip the '<@' and '>'
     user_id = reference_to_id(value.group())
-    user_profile = settings.SLACK_CLIENT.get_user_profile(user_id)
+    user_profile = cache.get_user_profile(user_id)
     return "@" + user_profile["name"] or user_id
 
 

--- a/response/slack/reference_utils.py
+++ b/response/slack/reference_utils.py
@@ -1,5 +1,7 @@
 import re
 
+from django.conf import settings
+
 
 def channel_reference(channel_id):
     if channel_id is None:
@@ -15,3 +17,11 @@ def reference_to_id(value):
     """take a string containing <@U123ABCD> refs and extract first match"""
     m = re.search(r"<@(U[A-Z0-9]+)>", value)
     return m.group(1) if m else None
+
+
+def user_ref_to_username(value):
+    """takes a <@U123ABCD> style ref and returns an @username"""
+    # strip the '<@' and '>'
+    user_id = reference_to_id(value.group())
+    user_profile = settings.SLACK_CLIENT.get_user_profile(user_id)
+    return "@" + user_profile["name"] or user_id

--- a/response/slack/reference_utils.py
+++ b/response/slack/reference_utils.py
@@ -1,3 +1,6 @@
+import re
+
+
 def channel_reference(channel_id):
     if channel_id is None:
         return None
@@ -6,3 +9,9 @@ def channel_reference(channel_id):
 
 def user_reference(user_id):
     return f"<@{user_id}>"
+
+
+def reference_to_id(value):
+    """take a string containing <@U123ABCD> refs and extract first match"""
+    m = re.search(r"<@(U[A-Z0-9]+)>", value)
+    return m.group(1) if m else None

--- a/response/slack/reference_utils.py
+++ b/response/slack/reference_utils.py
@@ -25,3 +25,10 @@ def user_ref_to_username(value):
     user_id = reference_to_id(value.group())
     user_profile = settings.SLACK_CLIENT.get_user_profile(user_id)
     return "@" + user_profile["name"] or user_id
+
+
+def slack_to_human_readable(value):
+    # replace user references (<@U3231FFD>) with usernames (@chrisevans)
+    value = re.sub(r"(<@U[A-Z0-9]+>)", user_ref_to_username, value)
+    value = re.sub(r"(<#C[A-Z0-9]+\|([\-a-zA-Z0-9]+)>)", r"#\2", value)
+    return value

--- a/response/templatetags/unslackify.py
+++ b/response/templatetags/unslackify.py
@@ -4,7 +4,7 @@ import emoji_data_python
 from django import template
 
 from response.slack.cache import get_user_profile
-from response.slack.client import slack_to_human_readable
+from response.slack.reference_utils import slack_to_human_readable
 
 register = template.Library()
 


### PR DESCRIPTION
Adds an additional field to actions and timeline events so that slack IDs can be represented in human-readable form. These fields are read-only as updates should be applied to the non-mapped field.

Note: With the ability to turn off input sanitization in #171 it's possible to store `<` and `>` in the fields for these models verbatim. The regex that replaces slack IDs will currently only work in this case.

Where there is existing escaped data, we could either modify the regex to match escaped entities like `&lt;` or write a data migration to un-escape existing values. I've decided both of those are outside the scope of this PR ;)