### PR TITLE
Limit the closing incident notification to working hours

### DIFF
--- a/response/slack/incident_notifications.py
+++ b/response/slack/incident_notifications.py
@@ -36,6 +36,10 @@ def remind_close_incident(incident: Incident):
     if datetime.now().weekday() in (5, 6):
         return
 
+    # Only remind during the day to prevent alerting people at unsociable hours
+    if datetime.now().hour not in range(9, 18):
+        return
+
     try:
         comms_channel = CommsChannel.objects.get(incident=incident)
         if not incident.is_closed():


### PR DESCRIPTION
The reminder to close an incident will happen exactly 24 hours after the incident was created which could be at a very unsociable hour. This change will ensure the reminder to close an incident only happens between 9am and 6pm.