### PR TITLE
Remove leading space from day in channel creation

### DIFF
--- a/response/slack/models/comms_channel.py
+++ b/response/slack/models/comms_channel.py
@@ -17,7 +17,7 @@ class CommsChannelManager(models.Manager):
         """
         Creates a comms channel in slack, and saves a reference to it in the DB
         """
-        time_string = datetime.now().strftime("%b-%e-%H-%M-%S")
+        time_string = datetime.now().strftime("%b-%-e-%H-%M-%S")
         name = f"inc-{time_string}".lower()
 
         try:


### PR DESCRIPTION
In `strftime`, %e has a leading space for single digit days.  For example the 5th of the month would print as ' 5' (note the space).

Prior to this change, we were including this space in the call to channels.create, and slack was replacing the space with an extra hyphen.

This meant an incident on November 5th would show as #inc-nov--5-20-51-01 rather than the desired name of #inc-nov-5-20-51-01.

Adding a '-' in the `%e` format trims leading whitespace which corrects the problem.