### PR TITLE
Make private a keyword arg

### DIFF
--- a/response/core/models/incident.py
+++ b/response/core/models/incident.py
@@ -14,7 +14,7 @@ class IncidentManager(models.Manager):
         reporter,
         report_time,
         report_only,
-        private,
+        private=False,
         summary=None,
         impact=None,
         lead=None,


### PR DESCRIPTION
I missed this in the initial review - it saves having to update
all projects which create incidents outside the response app.

False is a sensible default.