### PR TITLE
Deserialize event payload for API rendering

### DIFF
--- a/response/core/serializers.py
+++ b/response/core/serializers.py
@@ -1,4 +1,5 @@
 import emoji_data_python
+import json
 from rest_framework import serializers
 
 from response.core.models import Action, Event, ExternalUser, Incident, TimelineEvent
@@ -134,7 +135,12 @@ class IncidentSerializer(serializers.ModelSerializer):
 
 
 class EventSerializer(serializers.ModelSerializer):
+    payload = serializers.SerializerMethodField()
+
     class Meta:
         model = Event
         fields = ("id", "timestamp", "event_type", "payload")
         read_only_fields = ("id", "timestamp", "event_type", "payload")
+
+    def get_payload(self, instance):
+        return json.loads(instance.payload)

--- a/response/core/serializers.py
+++ b/response/core/serializers.py
@@ -1,5 +1,6 @@
-import emoji_data_python
 import json
+
+import emoji_data_python
 from rest_framework import serializers
 
 from response.core.models import Action, Event, ExternalUser, Incident, TimelineEvent

--- a/tests/api/test_events.py
+++ b/tests/api/test_events.py
@@ -26,5 +26,4 @@ def test_list_events(arf, api_user):
     for event in events:
         assert event["timestamp"]
         assert event["event_type"]
-        payload = json.loads(event["payload"])
-        assert payload["report"]
+        assert event["payload"]["report"]

--- a/tests/factories/event.py
+++ b/tests/factories/event.py
@@ -20,4 +20,4 @@ class EventFactory(factory.DjangoModelFactory):
     # Using an Incident/Event factory here fails with a mysterious error:
     # https://github.com/pytest-dev/pytest-django/issues/713 (using @pytest.mark...
     # didn't resolve it). For now, a static fixture suffices.
-    payload = {"report": "we're out of milk", "impact": "making tea is difficult"}
+    payload = {"report": "we are out of milk", "impact": "making tea is difficult"}


### PR DESCRIPTION
The payload starts life as an Incident or Event object,
rendered to a JSON string, then stored as a text field.

To enable the JSON renderer in Django Rest Framework to
render this as an object rather than a JSON-encoded string
the easiest option is to deserialize the field prior to
sending it to the renderer.

An alternative would be to override the from_db method on
the Event model, but since we don't need to modify the payload
anywhere, it's simpler to do this in the serializer.