### PR TITLE
Enable filtering events by timestamp

### DIFF
--- a/response/core/views.py
+++ b/response/core/views.py
@@ -87,6 +87,8 @@ class EventsViewSet(viewsets.ModelViewSet):
     serializer_class = serializers.EventSerializer
 
     def get_queryset(self):
-        from_ts = self.request.query_params.get('from', datetime.now(tz=None)-timedelta(days=1))
-        to_ts = self.request.query_params.get('to', datetime.now(tz=None))
+        from_ts = self.request.query_params.get(
+            "from", datetime.now(tz=None) - timedelta(days=1)
+        )
+        to_ts = self.request.query_params.get("to", datetime.now(tz=None))
         return Event.objects.filter(timestamp__range=(from_ts, to_ts))

--- a/response/core/views.py
+++ b/response/core/views.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from rest_framework import pagination, viewsets
 
 from response.core import serializers
@@ -83,3 +85,8 @@ class IncidentTimelineEventViewSet(viewsets.ModelViewSet):
 class EventsViewSet(viewsets.ModelViewSet):
     queryset = Event.objects.all()
     serializer_class = serializers.EventSerializer
+
+    def get_queryset(self):
+        from_ts = self.request.query_params.get('from', None)
+        to_ts = self.request.query_params.get('to', None)
+        return Event.objects.filter(timestamp__range=(from_ts, to_ts))

--- a/response/core/views.py
+++ b/response/core/views.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from rest_framework import pagination, viewsets
 
@@ -87,6 +87,6 @@ class EventsViewSet(viewsets.ModelViewSet):
     serializer_class = serializers.EventSerializer
 
     def get_queryset(self):
-        from_ts = self.request.query_params.get('from', None)
-        to_ts = self.request.query_params.get('to', None)
+        from_ts = self.request.query_params.get('from', datetime.now(tz=None)-timedelta(days=1))
+        to_ts = self.request.query_params.get('to', datetime.now(tz=None))
         return Event.objects.filter(timestamp__range=(from_ts, to_ts))

--- a/tests/api/test_events.py
+++ b/tests/api/test_events.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timedelta
 import json
 
 from django.urls import reverse
@@ -12,8 +13,8 @@ def test_list_events(arf, api_user):
 
     req = arf.get(reverse("event-list"))
     force_authenticate(req, user=api_user)
-    response = EventsViewSet.as_view({"get": "list"})(req)
 
+    response = EventsViewSet.as_view({"get": "list"})(req)
     assert response.status_code == 200, "Got non-200 response from API"
     content = json.loads(response.rendered_content)
 
@@ -27,3 +28,24 @@ def test_list_events(arf, api_user):
         assert event["timestamp"]
         assert event["event_type"]
         assert event["payload"]["report"]
+
+
+def test_filter_events(arf, api_user):
+    ts = datetime.now() + timedelta(days=30)
+    EventFactory(timestamp=ts)
+
+    query_params = {
+        "from": ts - timedelta(hours=1),
+        "to": ts + timedelta(hours=1)
+    }
+    req = arf.get(reverse("event-list"), data=query_params)
+    force_authenticate(req, user=api_user)
+
+    response = EventsViewSet.as_view({"get": "list"})(req)
+    assert response.status_code == 200, "Got non-200 response from API"
+    content = json.loads(response.rendered_content)
+
+    assert "results" in content, "Response didn't have results key"
+    events = content["results"]
+    assert len(events) == 1, "Expected one event"
+

--- a/tests/api/test_events.py
+++ b/tests/api/test_events.py
@@ -1,5 +1,5 @@
-from datetime import datetime, timedelta
 import json
+from datetime import datetime, timedelta
 
 from django.urls import reverse
 from rest_framework.test import force_authenticate
@@ -34,10 +34,7 @@ def test_filter_events(arf, api_user):
     ts = datetime.now() + timedelta(days=30)
     EventFactory(timestamp=ts)
 
-    query_params = {
-        "from": ts - timedelta(hours=1),
-        "to": ts + timedelta(hours=1)
-    }
+    query_params = {"from": ts - timedelta(hours=1), "to": ts + timedelta(hours=1)}
     req = arf.get(reverse("event-list"), data=query_params)
     force_authenticate(req, user=api_user)
 
@@ -48,4 +45,3 @@ def test_filter_events(arf, api_user):
     assert "results" in content, "Response didn't have results key"
     events = content["results"]
     assert len(events) == 1, "Expected one event"
-


### PR DESCRIPTION
Default is the last day if no `from` and `to` params are provided.