### PR TITLE
Omit events for private incidents

### DIFF
--- a/response/core/signals.py
+++ b/response/core/signals.py
@@ -12,7 +12,11 @@ logger = logging.getLogger(__name__)
 
 
 class ActionEventHandler:
+    @staticmethod
     def handle(sender, instance: Action, **kwargs):
+        if instance.incident.private:
+            logger.info(f"Skipping action post_save for private incident: {instance}")
+            return
         logger.info(f"Handling post_save for action: {instance}")
 
         event = Event()
@@ -29,7 +33,11 @@ class ActionEventHandler:
 
 
 class IncidentEventHandler:
+    @staticmethod
     def handle(sender, instance: Incident, **kwargs):
+        if instance.private:
+            logger.info(f"Skipping incident post_save for private incident: {instance}")
+            return
         logger.info(f"Handling post_save for incident: {instance}")
 
         event = Event()

--- a/tests/api/test_events.py
+++ b/tests/api/test_events.py
@@ -4,8 +4,44 @@ from datetime import datetime, timedelta
 from django.urls import reverse
 from rest_framework.test import force_authenticate
 
+from response.core.signals import ActionEventHandler, IncidentEventHandler
 from response.core.views import EventsViewSet
+from tests.factories.action import ActionFactory
 from tests.factories.event import EventFactory
+from tests.factories.incident import IncidentFactory
+
+
+def test_generate_incident_event(arf, api_user):
+    incident = IncidentFactory()
+    IncidentEventHandler.handle(None, incident)
+
+    req = arf.get(reverse("event-list"))
+    force_authenticate(req, user=api_user)
+
+    response = EventsViewSet.as_view({"get": "list"})(req)
+    assert response.status_code == 200, "Got non-200 response from API"
+    content = json.loads(response.rendered_content)
+
+    assert "results" in content, "Response didn't have results key"
+    events = content["results"]
+    assert len(events) == 1, "Expected one event"
+
+
+def test_generate_action_event(arf, api_user):
+    incident = IncidentFactory()
+    action = ActionFactory.create(incident=incident)
+    ActionEventHandler.handle(None, action)
+
+    req = arf.get(reverse("event-list"))
+    force_authenticate(req, user=api_user)
+
+    response = EventsViewSet.as_view({"get": "list"})(req)
+    assert response.status_code == 200, "Got non-200 response from API"
+    content = json.loads(response.rendered_content)
+
+    assert "results" in content, "Response didn't have results key"
+    events = content["results"]
+    assert len(events) == 1, "Expected one event"
 
 
 def test_list_events(arf, api_user):
@@ -45,3 +81,36 @@ def test_filter_events(arf, api_user):
     assert "results" in content, "Response didn't have results key"
     events = content["results"]
     assert len(events) == 1, "Expected one event"
+
+
+def test_omit_private_incident(arf, api_user):
+    incident = IncidentFactory(private=True)
+    IncidentEventHandler.handle(None, incident)
+
+    req = arf.get(reverse("event-list"))
+    force_authenticate(req, user=api_user)
+
+    response = EventsViewSet.as_view({"get": "list"})(req)
+    assert response.status_code == 200, "Got non-200 response from API"
+    content = json.loads(response.rendered_content)
+
+    assert "results" in content, "Response didn't have results key"
+    events = content["results"]
+    assert len(events) == 0, "Expected zero events"
+
+
+def test_omit_private_action(arf, api_user):
+    incident = IncidentFactory(private=True)
+    action = ActionFactory.create(incident=incident)
+    ActionEventHandler.handle(None, action)
+
+    req = arf.get(reverse("event-list"))
+    force_authenticate(req, user=api_user)
+
+    response = EventsViewSet.as_view({"get": "list"})(req)
+    assert response.status_code == 200, "Got non-200 response from API"
+    content = json.loads(response.rendered_content)
+
+    assert "results" in content, "Response didn't have results key"
+    events = content["results"]
+    assert len(events) == 0, "Expected zero events"


### PR DESCRIPTION
Tests could do with a bit of de-duplication, but it'd be good to do this
across all API tests.