### PR TITLE
Removed private incident logic

### DIFF
--- a/response/core/serializers.py
+++ b/response/core/serializers.py
@@ -103,7 +103,6 @@ class IncidentSerializer(serializers.ModelSerializer):
             "report",
             "report_time",
             "report_only",
-            "private",
             "reporter",
             "severity",
             "start_time",
@@ -126,10 +125,6 @@ class IncidentSerializer(serializers.ModelSerializer):
         instance.start_time = validated_data.get("start_time", instance.start_time)
         instance.summary = validated_data.get("summary", instance.summary)
         instance.severity = validated_data.get("severity", instance.severity)
-
-        # we only allow setting private to true, we don't want to allow private incidents becoming public
-        if not instance.private:
-            instance.private = validated_data.get("private", instance.private)
 
         instance.save()
         return instance

--- a/response/slack/action_handlers.py
+++ b/response/slack/action_handlers.py
@@ -85,17 +85,6 @@ def handle_edit_incident_button(ac: ActionContext):
         ),
     ]
 
-    if not ac.incident.private:
-        dialog_elements.append(
-            SelectWithOptions(
-                [("Yes (cant't be undone)", "yes")],
-                value=None,
-                label="Make the incident private?",
-                name="private",
-                optional=True,
-            )
-        )
-
     dialog = Dialog(
         title=f"Edit Incident {ac.incident.pk}",
         submit_label="Save",

--- a/response/slack/dialog_handlers.py
+++ b/response/slack/dialog_handlers.py
@@ -22,7 +22,6 @@ def report_incident(
     impact = submission["impact"]
     lead_id = submission["lead"]
     severity = submission["severity"]
-    private = True if submission.get("private", False) else False
 
     if "incident_type" in submission:
         report_only = submission["incident_type"] == "report"
@@ -46,7 +45,6 @@ def report_incident(
         reporter=reporter,
         report_time=datetime.now(),
         report_only=report_only,
-        private=private,
         summary=summary,
         impact=impact,
         lead=lead,
@@ -74,7 +72,6 @@ def edit_incident(
     impact = submission["impact"]
     lead_id = submission["lead"]
     severity = submission["severity"]
-    private = True if submission.get("private", False) else False
 
     lead = None
     if lead_id:
@@ -88,10 +85,6 @@ def edit_incident(
 
         if not severity and incident.severity:
             raise Exception("Cannot unset severity")
-
-        if private:
-            # making an incident private is irreversible
-            incident.private = private
 
         # deliberately update in this way the post_save signal gets sent
         # (required for the headline post to auto update)

--- a/response/slack/models/headline_post.py
+++ b/response/slack/models/headline_post.py
@@ -72,9 +72,6 @@ class HeadlinePost(models.Model):
             )
         )
 
-        if self.incident.private:
-            msg.add_block(Section(block_id="private", text=Text(f"🔒 Private comms")))
-
         msg.add_block(Divider())
 
         # Add additional info
@@ -100,19 +97,18 @@ class HeadlinePost(models.Model):
             )
         )
 
-        if not self.incident.private:
-            doc_url = urljoin(
-                settings.SITE_URL,
-                reverse("incident_doc", kwargs={"incident_id": self.incident.pk}),
+        doc_url = urljoin(
+            settings.SITE_URL,
+            reverse("incident_doc", kwargs={"incident_id": self.incident.pk}),
+        )
+        msg.add_block(
+            Section(
+                block_id="incident_doc",
+                text=Text(f"📄 Document: <{doc_url}|Incident {self.incident.pk}>"),
             )
-            msg.add_block(
-                Section(
-                    block_id="incident_doc",
-                    text=Text(f"📄 Document: <{doc_url}|Incident {self.incident.pk}>"),
-                )
-            )
+        )
 
-        if not self.incident.report_only and not self.incident.private:
+        if not self.incident.report_only:
             channel_ref = (
                 channel_reference(self.comms_channel.channel_id)
                 if self.comms_channel
@@ -176,8 +172,8 @@ class HeadlinePost(models.Model):
 
 @headline_post_action(order=100)
 def create_comms_channel_action(headline_post):
-    if headline_post.incident.report_only or headline_post.incident.private:
-        # Reports and private incidents don't link to comms channels
+    if headline_post.incident.report_only:
+        # Reports don't link to comms channels
         return None
     if headline_post.comms_channel:
         # No need to create an action, channel already exists

--- a/response/slack/views.py
+++ b/response/slack/views.py
@@ -70,16 +70,6 @@ def slash_command(request):
         )
 
     dialog.add_element(
-        SelectWithOptions(
-            [("Yes (can't be undone)", "yes")],
-            label="Is this a private incident?",
-            hint="Will sensitive information be shared in incident comms?",
-            name="private",
-            optional=True,
-        )
-    )
-
-    dialog.add_element(
         TextArea(
             label="Summary",
             name="summary",

--- a/response/ui/views.py
+++ b/response/ui/views.py
@@ -13,10 +13,6 @@ def incident_doc(request: HttpRequest, incident_id: str):
     except Incident.DoesNotExist:
         raise Http404("Incident does not exist")
 
-    # private incident details cannot be viewed by anyone
-    if incident.private:
-        return HttpResponseForbidden()
-
     events = PinnedMessage.objects.filter(incident=incident).order_by("timestamp")
     user_stats = UserStats.objects.filter(incident=incident).order_by("-message_count")[
         :5

--- a/response/ui/views.py
+++ b/response/ui/views.py
@@ -1,4 +1,4 @@
-from django.http import Http404, HttpRequest, HttpResponseForbidden
+from django.http import Http404, HttpRequest
 from django.shortcuts import render
 
 from response.core.models import Incident

--- a/tests/api/test_incidents.py
+++ b/tests/api/test_incidents.py
@@ -268,53 +268,6 @@ def test_cannot_unset_severity(arf, api_user):
     ), "Got 200 response from API when we expected an error"
 
 
-def test_make_incident_private(arf, api_user):
-    """
-    Tests that we cannot unset the incident severity
-    """
-
-    incident = IncidentFactory.create()
-    serializer = serializers.IncidentSerializer(incident)
-    updated = serializer.data
-
-    updated["private"] = True  # unset severity
-
-    req = arf.put(
-        reverse("incident-detail", kwargs={"pk": incident.pk}), updated, format="json"
-    )
-    force_authenticate(req, user=api_user)
-
-    response = IncidentViewSet.as_view({"put": "update"})(req, pk=incident.pk)
-    print(response.rendered_content)
-    assert response.status_code == 200, "Incident update succeeded"
-
-    new_incident = Incident.objects.get(pk=incident.pk)
-    assert new_incident.private, "Incident not marked as private"
-
-
-def test_cannot_make_private_incident_public(arf, api_user):
-    """
-    Tests that we cannot make private incidents public
-    """
-
-    incident = IncidentFactory.create(private=True)
-    serializer = serializers.IncidentSerializer(incident)
-    updated = serializer.data
-
-    updated["private"] = False
-    req = arf.put(
-        reverse("incident-detail", kwargs={"pk": incident.pk}), updated, format="json"
-    )
-    force_authenticate(req, user=api_user)
-    response = IncidentViewSet.as_view({"put": "update"})(req, pk=incident.pk)
-
-    print(response.rendered_content)
-    assert response.status_code == 200, "Update failed"
-
-    new_incident = Incident.objects.get(pk=incident.pk)
-    assert new_incident.private, "Private incident marked as public"
-
-
 def test_cannot_access_incident_logged_out_if_configured(client, db, settings):
     settings.RESPONSE_LOGIN_REQUIRED = True
 
@@ -324,16 +277,6 @@ def test_cannot_access_incident_logged_out_if_configured(client, db, settings):
 
     assert response.status_code == 302
     assert response["location"].startswith(settings.LOGIN_URL)
-
-
-def test_cannot_access_private_incident(client, db, settings):
-    settings.RESPONSE_LOGIN_REQUIRED = False
-
-    incident = IncidentFactory(private=True)
-
-    response = client.get(reverse("incident_doc", args=(incident.pk,)))
-
-    assert response.status_code == 403
 
 
 def test_can_access_incident_logged_out_if_configured(client, db, settings):

--- a/tests/test.py
+++ b/tests/test.py
@@ -171,7 +171,6 @@ def test_edit_incident(post_from_slack_api, mock_slack):
         reporter=user,
         report_time=datetime.now(),
         report_only=False,
-        private=False,
         summary="Testing editing incidents - before",
         impact="Lots",
         lead=user,
@@ -207,73 +206,6 @@ def test_edit_incident(post_from_slack_api, mock_slack):
     timeout_secs = 2
     backoff = 0.2
     i = Incident.objects.filter(summary=newsummary)
-    while True:
-        d = datetime.now() - start_time
-        if d.total_seconds() > timeout_secs:
-            pytest.fail(f"waited {timeout_secs}s for condition")
-            return
-        time.sleep(backoff)
-
-        if i.exists():
-            break
-
-    # Assert that the headline post gets updated
-    mock_slack.send_or_update_message_block.assert_called_with(
-        "incident-channel-id", blocks=ANY, fallback_text=ANY, ts="123"
-    )
-
-
-@pytest.mark.django_db(transaction=True)
-def test_edit_private_incident(post_from_slack_api, mock_slack):
-    mock_slack.send_or_update_message_block.return_value = {"ts": "123"}
-    mock_slack.get_user_profile.return_value = {"ts": "123", "name": "Opsy McOpsface"}
-
-    user = ExternalUser.objects.get_or_create(
-        app_id="slack", external_id="U123", display_name="Opsy McOpsface"
-    )[0]
-
-    incident = Incident.objects.create_incident(
-        report="Something happened",
-        reporter=user,
-        report_time=datetime.now(),
-        report_only=False,
-        private=True,
-        summary="Testing editing incidents - before",
-        impact="Lots",
-        lead=user,
-        severity="1",
-    )
-
-    newsummary = "Testing editing incidents - after"
-    data = {
-        "payload": json.dumps(
-            {
-                "type": "dialog_submission",
-                "callback_id": "incident-edit-dialog",
-                "user": {"id": "U123"},
-                "channel": {"id": "D123"},
-                "response_url": "https://fake-response-url",
-                "submission": {
-                    "report": "",
-                    "summary": newsummary,
-                    "impact": "",
-                    "lead": "U123",
-                    "severity": "1",
-                    "incident_type": "",
-                },
-                "state": incident.id,
-            }
-        )
-    }
-    r = post_from_slack_api("action", data)
-
-    assert r.status_code == 200
-
-    start_time = datetime.now()
-    timeout_secs = 2
-    backoff = 0.2
-    # we assert that the incident is still private, even though the update omitted the property
-    i = Incident.objects.filter(summary=newsummary, private=True)
     while True:
         d = datetime.now() - start_time
         if d.total_seconds() > timeout_secs:


### PR DESCRIPTION
It feels a little too 'MVP' right now, so we're undoing until it's a more fully formed feature.