### PR TITLE
Consistent handling of cache access

### DIFF
--- a/response/slack/cache.py
+++ b/response/slack/cache.py
@@ -79,7 +79,7 @@ def get_user_profile_by_email(email):
         - or else from the Slack API
     """
     if not email:
-        return None
+        raise SlackError("Can't fetch user without an email")
 
     try:
         external_user = ExternalUser.objects.get(email=email)


### PR DESCRIPTION
Mixing return None with exceptions makes it harder to handle the different failure cases.
This makes it easier as callers can simply handle the SlackError exception.