### PR TITLE
allow overriding DB access defaults with env variables

### DIFF
--- a/demo/demo/settings/dev.py
+++ b/demo/demo/settings/dev.py
@@ -9,10 +9,10 @@ if os.environ.get("POSTGRES"):
     DATABASES = {
         "default": {
             "ENGINE": "django.db.backends.postgresql",
-            "HOST": "db",
-            "PORT": "5432",
-            "USER": "postgres",
-            "NAME": "postgres",
+            "HOST": os.getenv("DB_HOST", "db"),
+            "PORT": os.getenv("DB_PORT", "5432"),
+            "USER": os.getenv("DB_USER", "postgres"),
+            "NAME": os.getenv("DB_NAME", "postgres"),
         }
     }
 


### PR DESCRIPTION
When running a dev setup I had to change those in my local setup, and given this was a copy of the demo app - this might be interesting for other's as well? :-) 

This should keep previous behaviour the same, but allow overriding the dev DB access defaults via env variables.