### PR TITLE
Updates for new slack bot user permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,12 +101,15 @@ urlpatterns = [
 - In the OAuth and Permissions page, scroll down to scopes.
 
 - Add the following scopes:
+  - `app_mentions:read`
   - `channels:history`
+  - `channels:join`
+  - `channels:manage`
   - `channels:read`
   - `channels:write`
-  - `reactions:write`
   - `chat:write:bot`
   - `chat:write:user`
+  - `reactions:write`
   - `users:read`
   - `users:read.email`
 

--- a/response/slack/client.py
+++ b/response/slack/client.py
@@ -172,7 +172,6 @@ class SlackClient(object):
     def send_message(self, channel_id, text, attachments=None, thread_ts=None):
         return self.api_call(
             "chat.postMessage",
-            as_user=False,
             channel=channel_id,
             text=text,
             attachments=attachments,
@@ -182,7 +181,6 @@ class SlackClient(object):
     def send_ephemeral_message(self, channel_id, user_id, text, attachments=None):
         return self.api_call(
             "chat.postEphemeral",
-            as_user=False,
             channel=channel_id,
             text=text,
             user=user_id,


### PR DESCRIPTION
Slack have re-worked their bot user permission model, and broken the documentation here (and in many other apps -.-)

https://api.slack.com/authentication/token-types#granular_bot


This was the only code usage that prevented me trying out the app, I had to add a lot more permissions than was previously documented as well

https://api.slack.com/methods/chat.postMessage#arg_as_user

cc @ChrisAnn 👋 