### PR TITLE
Exclude bot messages from being handled by the bot

### DIFF
--- a/response/slack/decorators/event_handler.py
+++ b/response/slack/decorators/event_handler.py
@@ -47,7 +47,7 @@ def handle_event(payload):
     logger.info(f"Handling Slack event {event} of type {event_type}")
 
     # ignore bot messages
-    if event.get("subtype", None) == "bot_message":
+    if event.get("subtype", None) == "bot_message" or event.get("bot_id", None):
         logger.info("Ignoring bot message")
         return
 


### PR DESCRIPTION
The behaviour here has changed after we've switched to using bot tokens.  We now check whether a message has an attached bot_id to determine whether it's come from a humna or a bot.