### PR TITLE
Fix broken link from incident list when UI isn't at the root

### DIFF
--- a/response/templates/home.html
+++ b/response/templates/home.html
@@ -20,9 +20,9 @@
         {% for incident in incidents %}
         <li>
           {{ incident.severity_emoji }}
-          <a href="/incident/{{incident.pk}}" target="_blank">Incident {{incident.pk}}&nbsp;</a>
+          <a href="{% url 'incident_doc' incident.pk %}" target="_blank">Incident {{ incident.pk }}&nbsp;</a>
           <span class="badge {{ incident.badge_type }} blink_me">{{ incident.status_text|upper }}</span>
-          - {{incident.report}}
+          - {{ incident.report }}
         </li>
         {% endfor %}
       </ul>


### PR DESCRIPTION
In our installation, the URLs are setup in a way that the UI part has its URLs starting with `/ui/`. When deploying the latest version, we got broken links from the new home page because it has hardcoded path, instead of using the `url` template tag to reverse by name.