### PR TITLE
Remove deprecated Slack channel API calls. Use conversations API.

### DIFF
--- a/response/slack/action_handlers.py
+++ b/response/slack/action_handlers.py
@@ -1,8 +1,6 @@
 import logging
 from datetime import datetime
 
-from django.conf import settings
-
 from response.core.models.incident import Incident
 from response.slack.decorators import ActionContext, action_handler
 from response.slack.dialog_builder import (
@@ -30,14 +28,6 @@ def handle_create_comms_channel(ac: ActionContext):
         return
 
     comms_channel = CommsChannel.objects.create_comms_channel(ac.incident)
-
-    # Invite the bot to the channel
-    try:
-        settings.SLACK_CLIENT.invite_user_to_channel(
-            settings.INCIDENT_BOT_ID, comms_channel.channel_id
-        )
-    except Exception as ex:
-        logger.error(ex)
 
     # Update the headline post to link to this
     headline_post = HeadlinePost.objects.get(incident=ac.incident)

--- a/response/slack/client.py
+++ b/response/slack/client.py
@@ -93,7 +93,7 @@ class SlackClient(object):
 
         while next_cursor != "":
             response = self.api_call(
-                "channels.list",
+                "conversations.list",
                 exclude_archived=not auto_unarchive,
                 exclude_members=True,
                 limit=800,
@@ -141,12 +141,12 @@ class SlackClient(object):
         return None
 
     def create_channel(self, name):
-        response = self.api_call("channels.create", name=name)
+        response = self.api_call("conversations.create", name=name)
         try:
             return response["channel"]["id"]
         except KeyError:
             raise SlackError(
-                "Got unexpected response from Slack API for channels.create - couldn't find channel.id key"
+                "Got unexpected response from Slack API for conversations.create - couldn't find channel.id key"
             )
 
     def get_or_create_channel(self, channel_name, auto_unarchive=False):
@@ -161,11 +161,11 @@ class SlackClient(object):
 
     def set_channel_topic(self, channel_id, channel_topic):
         return self.api_call(
-            "channels.setTopic", channel=channel_id, topic=channel_topic
+            "conversations.setTopic", channel=channel_id, topic=channel_topic
         )
 
     def unarchive_channel(self, channel_id):
-        response = self.api_call("channels.unarchive", channel=channel_id)
+        response = self.api_call("conversations.unarchive", channel=channel_id)
         if not response.get("ok", False):
             raise SlackError(f"Couldn't unarchive channel {channel_id}")
 
@@ -227,13 +227,15 @@ class SlackClient(object):
             )
 
     def invite_user_to_channel(self, user_id, channel_id):
-        return self.api_call("channels.invite", user=user_id, channel=channel_id)
+        return self.api_call(
+            "conversations.invite", users=[user_id], channel=channel_id
+        )
 
     def join_channel(self, channel_id):
-        return self.api_call("channels.join", name=channel_id)
+        return self.api_call("conversations.join", channel=channel_id)
 
     def leave_channel(self, channel_id):
-        return self.api_call("channels.leave", channel=channel_id)
+        return self.api_call("conversations.leave", channel=channel_id)
 
     def get_user_profile(self, user_id):
         if not user_id:
@@ -268,7 +270,7 @@ class SlackClient(object):
 
         new_name = slugify(f"{prefix}{new_name}", max_length=80)
 
-        return self.api_call("channels.rename", channel=channel_id, name=new_name)
+        return self.api_call("conversations.rename", channel=channel_id, name=new_name)
 
     def dialog_open(self, dialog, trigger_id):
         return self.api_call("dialog.open", trigger_id=trigger_id, dialog=dialog)

--- a/response/slack/models/comms_channel.py
+++ b/response/slack/models/comms_channel.py
@@ -31,8 +31,8 @@ class CommsChannelManager(models.Manager):
         # If the channel already existed we will need to join it
         # If we are already in the channel as we created it, then this is a No-Op
         try:
-            logger.info(f"Joining channel {name}")
-            settings.SLACK_CLIENT.join_channel(name)
+            logger.info(f"Joining channel {name} {channel_id}")
+            settings.SLACK_CLIENT.join_channel(channel_id)
         except SlackError as e:
             logger.error(f"Failed to join comms channel {e}")
             raise


### PR DESCRIPTION
Fixes #218 

Pay particular attention to `conversations.join` -- the API is subtly different; Channel ID is required and not channel name.

Edit: there was also a change around `conversations.invite`. I updated this (send a list of users vs. single user), however you do get an error:

```
ERROR - action_handlers - Error calling Slack API endpoint 'conversations.invite': cant_invite_self
```

It seems this inviting of the bot user is unnecessary, as the bot joins the channel anyway during creation.  