### PR TITLE
Ensure the navbar links to the incident list

### DIFF
--- a/response/apps.py
+++ b/response/apps.py
@@ -21,3 +21,8 @@ class ResponseConfig(AppConfig):
         site_settings.RESPONSE_LOGIN_REQUIRED = getattr(
             site_settings, "RESPONSE_LOGIN_REQUIRED", True
         )
+
+        for template in site_settings.TEMPLATES:
+            context_processors = template.get("OPTIONS", {}).get("context_processors")
+            if context_processors:
+                context_processors.append("response.core.context_processors.site")

--- a/response/core/context_processors.py
+++ b/response/core/context_processors.py
@@ -1,0 +1,5 @@
+from django.conf import settings
+
+
+def site(request):
+    return {"SITE_URL": settings.SITE_URL}

--- a/response/templates/base.html
+++ b/response/templates/base.html
@@ -27,8 +27,8 @@
   <!-- Navigation -->
   <nav class="navbar navbar-expand-lg navbar-dark bg-dark static-top">
     <div class="container">
-      <a class="navbar-brand" href="#">
-        <img  id="logo" src="{% static "images/response.png" %}" />
+      <a class="navbar-brand" href="{{ SITE_URL }}/">
+        <img id="logo" src="{% static "images/response.png" %}" />
         <strong>Response</strong>
       </a>
 


### PR DESCRIPTION
Currently the navbar links to `#` so is a no-op.

This change makes the navbar link to `/` on whatever URL `SITE_URL` is configured as.

I have zero Django experience so I'm not sure if this is a sensible way of making this change, but I've verified it works as expected in our test setup.