### PR TITLE
fix volume mount issues with SELINUX

### DIFF
--- a/demo/docker-compose.yaml
+++ b/demo/docker-compose.yaml
@@ -18,7 +18,7 @@ services:
     env_file: .env
     volumes:
       - ./:/app
-      - ../:/response
+      - ../:/response:z
       - pypd:/app/pypd
     stdin_open: true
     tty: true

--- a/demo/docker-compose.yaml
+++ b/demo/docker-compose.yaml
@@ -17,7 +17,7 @@ services:
       POSTGRES: "true"
     env_file: .env
     volumes:
-      - ./:/app
+      - ./:/app:z
       - ../:/response:z
       - pypd:/app/pypd
     stdin_open: true


### PR DESCRIPTION
On my fedora 32 workstation, I had the two following issues when doing `docker-compose up`

```
response    | bash: /app/startup.sh: Permission denied
response exited with code 126

```

```
response    | ERROR: File "setup.py" not found. Directory cannot be installed in editable mode: /response
...
ModuleNotFoundError: No module named 'response
```

To solve thoses errors I followed [this suggestion](https://github.com/composer/docker/issues/7#issuecomment-351974111) to configure [the selinux label on the volume.](https://docs.docker.com/storage/bind-mounts/#configure-the-selinux-label)