### PR TITLE
Restrict incident creation based on INCIDENT_REPORT_CHANNEL_ID

### DIFF
--- a/response/slack/views.py
+++ b/response/slack/views.py
@@ -40,8 +40,22 @@ def slash_command(request):
     """
 
     user_id = request.POST.get("user_id")
+    channel_id = request.POST.get("channel_id")
     trigger_id = request.POST.get("trigger_id")
     report = request.POST.get("text")
+
+    if (
+        settings.INCIDENT_REPORT_CHANNEL_ID
+        and channel_id != settings.INCIDENT_REPORT_CHANNEL_ID
+    ):
+        settings.SLACK_CLIENT.send_ephemeral_message(
+            channel_id,
+            user_id,
+            f"Looks like you are trying to report an incident in the wrong "
+            f"channel :thinking_face:\n"
+            f"The correct place is <#{settings.INCIDENT_REPORT_CHANNEL_ID}>",
+        )
+        return HttpResponse()
 
     dialog = Dialog(
         title="Report an Incident",

--- a/tests/test.py
+++ b/tests/test.py
@@ -5,6 +5,7 @@ from unittest import mock
 from unittest.mock import ANY
 
 import pytest
+from django.conf import settings
 from django.urls import reverse
 
 from response.core.models import ExternalUser, Incident
@@ -26,11 +27,50 @@ def test_slash_command_invalid_signature(client):
 
 
 def test_slash_command_invokes_dialog(post_from_slack_api, mock_slack):
-    data = {"user_id": "U123", "trigger_id": "foo"}
+    data = {
+        "user_id": "U123",
+        "trigger_id": "foo",
+        "channel_id": settings.INCIDENT_REPORT_CHANNEL_ID,
+    }
     r = post_from_slack_api("slash_command", data)
 
     assert r.status_code == 200
     mock_slack.dialog_open.assert_called_once_with(dialog=ANY, trigger_id="foo")
+
+
+def test_slash_command_invokes_dialog_from_anywhere_if_INCIDENT_REPORT_CHANNEL_ID_isnt_set(
+    post_from_slack_api, mock_slack
+):
+    data = {
+        "user_id": "U123",
+        "trigger_id": "foo",
+        "channel_id": "not-origin-incident-channel",
+    }
+    settings.INCIDENT_REPORT_CHANNEL_ID = ""
+    r = post_from_slack_api("slash_command", data)
+
+    assert r.status_code == 200
+    mock_slack.dialog_open.assert_called_once_with(dialog=ANY, trigger_id="foo")
+
+
+def test_incident_can_only_be_created_from_channel_set_in_INCIDENT_REPORT_CHANNEL_ID(
+    post_from_slack_api, mock_slack
+):
+    data = {
+        "user_id": "U123",
+        "trigger_id": "foo",
+        "channel_id": "not-origin-incident-channel",
+    }
+    r = post_from_slack_api("slash_command", data)
+
+    assert r.status_code == 200
+    mock_slack.send_ephemeral_message.assert_called_with(
+        "not-origin-incident-channel",
+        "U123",
+        f"Looks like you are trying to report an incident in the wrong "
+        f"channel :thinking_face:\n"
+        f"The correct place is <#{settings.INCIDENT_REPORT_CHANNEL_ID}>",
+    )
 
 
 @pytest.mark.django_db(transaction=True)


### PR DESCRIPTION
### reason

By default, it is possible to create an incident from any Slack channel. This can create more workload on people responsible for dealing with the incidents because anyone else is able to raise an incident that they then have to triage.

### proposed solution

Use the environment variable `INCIDENT_REPORT_CHANNEL_ID` by only allowing creation of incidents if the current channel is the same as the value in the environment variable. When `INCIDENT_REPORT_CHANNEL_ID` is not set, it's then possible to create incidents from any channel.