### PR TITLE
Configurable Slack Ephemeral Messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Follow [these instructions](./docs/slack_app_create.md) to create a new Slack Ap
 | `INCIDENT_CHANNEL_ID`  | When an incident is declared, a 'headline' post is sent to a central channel.<br /><br />See the [demo app settings](./demo/demo/settings/dev.py) for an example of how to get the incident channel ID from the Slack API. |
 | `INCIDENT_BOT_ID`  | We want to invite the Bot to all Incident Channels, so need to know its ID.<br /><br />See the [demo app settings](./demo/demo/settings/dev.py) for an example of how to get the bot ID from the Slack API. |
 | `SLACK_CLIENT`  | Response needs a shared global instance of a Slack Client to talk to the Slack API. Typically this does not require any additional configuration. <br /><pre>from response.slack.client import SlackClient<br />SLACK_CLIENT = SlackClient(SLACK_TOKEN)</pre> |
+|`SLACK_EPHEMERAL_RESPONSES` | JSON formatted list of command names to which the Slack response should be sent as an [Ephemeral Message](https://api.slack.com/messaging/managing#ephemeral). All aliases for a single command need to be added to this list.
 
 ## 3. Running the server
 

--- a/demo/demo/settings/prod.py
+++ b/demo/demo/settings/prod.py
@@ -1,3 +1,4 @@
+import json
 import os
 
 from .base import *  # noqa: F401, F403
@@ -47,6 +48,8 @@ LOGGING = {
 
 SLACK_TOKEN = get_env_var("SLACK_TOKEN")
 SLACK_SIGNING_SECRET = get_env_var("SLACK_SIGNING_SECRET")
+SLACK_EPHEMERAL_RESPONSES = json.loads(os.getenv("SLACK_EPHEMERAL_RESPONSES",
+                                                 "[]"))
 INCIDENT_CHANNEL_NAME = get_env_var("INCIDENT_CHANNEL_NAME")
 INCIDENT_REPORT_CHANNEL_NAME = get_env_var("INCIDENT_REPORT_CHANNEL_NAME")
 INCIDENT_BOT_NAME = get_env_var("INCIDENT_BOT_NAME")

--- a/response/slack/decorators/incident_command.py
+++ b/response/slack/decorators/incident_command.py
@@ -126,7 +126,14 @@ def handle_incident_command(command_name, message, thread_ts, channel_id, user_i
             react_not_ok(channel_id, thread_ts)
 
         if response:
-            settings.SLACK_CLIENT.send_message(comms_channel.channel_id, response)
+            if command_name in settings.SLACK_EPHEMERAL_RESPONSES:
+                settings.SLACK_CLIENT.send_ephemeral_message(
+                    channel_id,
+                    user_id,
+                    response
+                )
+            else:
+                settings.SLACK_CLIENT.send_message(comms_channel.channel_id, response)
 
     except CommsChannel.DoesNotExist:
         logger.error("No matching incident found for this channel")


### PR DESCRIPTION
Introduce a setting to allow users to configure which Slack commands
will response with an ephemeral message. This was motivated by wanting
to turn the "help" command response into an ephemeral message to prevent it from
creating noise in the incident room.