### PR TITLE
Incident document page minor style changes

### DIFF
--- a/response/static/incident_doc.css
+++ b/response/static/incident_doc.css
@@ -8,7 +8,7 @@
 #status .live {
   padding: 5px;
   background: red;
-  color: lightpink;
+  color: white;
   margin-right: 5px;
   animation: blinker 1s linear infinite;
 }
@@ -16,7 +16,7 @@
 #status .resolved {
   padding: 5px;
   background: green;
-  color: lightgreen;
+  color: white;
   margin-right: 5px;
 }
 

--- a/response/templates/incident_doc.html
+++ b/response/templates/incident_doc.html
@@ -15,7 +15,7 @@
         {% comment %} ----- Heading ----- {% endcomment %}
         <h1 class="mt-3" id="title"><a href="">Incident {{ incident.pk }}</a></h1>
         <div id="status"><strong class="{{ incident.status_text }} blink_me">{{ incident.status_text|upper }}</strong>
-        {% if incident.severity_text %}- {{ incident.severity_text|upper}} SEVERITY{% endif %}</div>
+        {% if incident.severity_text %}— {{ incident.severity_text|upper}} SEVERITY{% endif %}</div>
     </div>
 
     <div class="col-lg-12">


### PR DESCRIPTION
I just set up the project demo to try it out, I noticed some minor styling things I would change. These are mostly depending on preference.

Changes:

1. Change font colour to be white in the incident status badge.
1. Change incident status dash from hyphen to an em dash.

Before:
<img width="395" alt="Screen Shot 2021-09-15 at 5 35 19 PM" src="https://user-images.githubusercontent.com/553444/133473864-e2d1799e-3485-47d1-8b39-31dd3aa32479.png">

After:
<img width="397" alt="Screen Shot 2021-09-15 at 5 33 54 PM" src="https://user-images.githubusercontent.com/553444/133473874-9deee0ae-f0fa-4cca-b487-0b513f793eab.png">
