### PR TITLE
Remove unused `statuspageio` dependency

### DIFF
--- a/response/slack/models/comms_channel.py
+++ b/response/slack/models/comms_channel.py
@@ -17,7 +17,7 @@ class CommsChannelManager(models.Manager):
         """
         Creates a comms channel in slack, and saves a reference to it in the DB
         """
-        time_string = datetime.now().strftime("%b-%-e-%H-%M-%S")
+        time_string = datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
         name = f"inc-{time_string}".lower()
 
         try:

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@ INSTALL_REQUIRES = [
     "markdown2>=2.3.7",
     "python-slugify>=1.2.6",
     "slackclient>=1.3,<2",
-    "statuspageio>=0.0.1",
 ]
 
 # allow setup.py to be run from any path


### PR DESCRIPTION
- It appears to be unused and the [upstream project](https://pypi.org/project/statuspageio/) is seemingly unmaintained (not updated since 2016)
- It also blocks installs when using versions of `setuptools` > 57.5.0
  due to the same issue described in: https://github.com/tikitu/jsmin/issues/33

You can re-create the issue with installing like so (tested with Python 3.9.7):
```bash
mkdir test && cd test
pip install poetry
poetry init --no-interaction
poetry add django-incident-response
```

Output:
```bash
Using version ^0.5.1 for django-incident-response

Updating dependencies
Resolving dependencies... (2.7s)

Writing lock file

Package operations: 2 installs, 0 updates, 0 removals

  • Installing statuspageio (0.0.1): Failed

  EnvCommandError

  Command ['/Users/james/Library/Caches/pypoetry/virtualenvs/test-B6-Zaf2c-py3.9/bin/pip', 'install', '--no-deps', 'file:///Users/james/Library/Caches/pypoetry/artifacts/41/99/42/2c8b6751dabc5bbd0df9ba8cc2a661cc3f1585a192c246378cefee45b2/statuspageio-0.0.1.tar.gz'] errored with the following return code 1, and output:
  Processing /Users/james/Library/Caches/pypoetry/artifacts/41/99/42/2c8b6751dabc5bbd0df9ba8cc2a661cc3f1585a192c246378cefee45b2/statuspageio-0.0.1.tar.gz
      ERROR: Command errored out with exit status 1:
       command: /Users/james/Library/Caches/pypoetry/virtualenvs/test-B6-Zaf2c-py3.9/bin/python -c 'import io, os, sys, setuptools, tokenize; sys.argv[0] = '"'"'/private/var/folders/g3/4y5gv74s0ld5n5y9nk4tm9k80000gn/T/pip-req-build-xyw82gmk/setup.py'"'"'; __file__='"'"'/private/var/folders/g3/4y5gv74s0ld5n5y9nk4tm9k80000gn/T/pip-req-build-xyw82gmk/setup.py'"'"';f = getattr(tokenize, '"'"'open'"'"', open)(__file__) if os.path.exists(__file__) else io.StringIO('"'"'from setuptools import setup; setup()'"'"');code = f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /private/var/folders/g3/4y5gv74s0ld5n5y9nk4tm9k80000gn/T/pip-pip-egg-info-4zwym1z0
           cwd: /private/var/folders/g3/4y5gv74s0ld5n5y9nk4tm9k80000gn/T/pip-req-build-xyw82gmk/
      Complete output (1 lines):
      error in statuspageio setup command: use_2to3 is invalid.
      ----------------------------------------
  WARNING: Discarding file:///Users/james/Library/Caches/pypoetry/artifacts/41/99/42/2c8b6751dabc5bbd0df9ba8cc2a661cc3f1585a192c246378cefee45b2/statuspageio-0.0.1.tar.gz. Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
  ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
  WARNING: You are using pip version 21.2.4; however, version 21.3.1 is available.
  You should consider upgrading via the '/Users/james/Library/Caches/pypoetry/virtualenvs/test-B6-Zaf2c-py3.9/bin/python -m pip install --upgrade pip' command.


  at ~/.asdf/installs/python/3.9.7/lib/python3.9/site-packages/poetry/utils/env.py:1183 in _run
      1179│                 output = subprocess.check_output(
      1180│                     cmd, stderr=subprocess.STDOUT, **kwargs
      1181│                 )
      1182│         except CalledProcessError as e:
    → 1183│             raise EnvCommandError(e, input=input_)
      1184│
      1185│         return decode(output)
      1186│
      1187│     def execute(self, bin, *args, **kwargs):


Failed to add packages, reverting the pyproject.toml file to its original content.
```